### PR TITLE
위젯의 텍스트 색깔을 설정할 수 있도록 수정

### DIFF
--- a/.idea/jarRepositories.xml
+++ b/.idea/jarRepositories.xml
@@ -26,5 +26,10 @@
       <option name="name" value="MavenRepo" />
       <option name="url" value="https://repo.maven.apache.org/maven2/" />
     </remote-repository>
+    <remote-repository>
+      <option name="id" value="maven" />
+      <option name="name" value="maven" />
+      <option name="url" value="https://jitpack.io" />
+    </remote-repository>
   </component>
 </project>

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -77,6 +77,9 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-viewmodel-ktx:$lifecycle_version"
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_extension_version"
 
+    implementation "androidx.datastore:datastore-preferences:$datastore_version"
+    implementation "androidx.datastore:datastore:$datastore_version"
+
     implementation 'com.orhanobut:logger:2.2.0'
 
     // Hilt dependency

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -89,6 +89,9 @@ dependencies {
     // Make Hilt generate code in the androidTest folder
     kaptAndroidTest "com.google.dagger:hilt-android-compiler:$hilt_version"
 
+    // Color picker
+    implementation 'com.github.QuadFlask:colorpicker:0.0.15'
+
     implementation project(':data')
     implementation project(':domain')
 }

--- a/app/src/main/java/hsk/practice/myvoca/extensions.kt
+++ b/app/src/main/java/hsk/practice/myvoca/extensions.kt
@@ -1,10 +1,19 @@
 package hsk.practice.myvoca
 
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStore
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.Observer
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
 
+/**
+ * Preferences DataStore object. Delegated by preferenceDataStore().
+ * Once this property is initialized, it can be accessed through the whole application.
+ */
+val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
 
 /**
  * Checks if the given string contains only alphabet.

--- a/app/src/main/java/hsk/practice/myvoca/widget/WidgetActivity.kt
+++ b/app/src/main/java/hsk/practice/myvoca/widget/WidgetActivity.kt
@@ -5,10 +5,14 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
+import com.flask.colorpicker.ColorPickerView
+import com.flask.colorpicker.builder.ColorPickerDialogBuilder
 import com.hsk.data.VocaRepository
 import com.orhanobut.logger.Logger
 import dagger.hilt.android.AndroidEntryPoint
+import hsk.practice.myvoca.R
 import hsk.practice.myvoca.databinding.ActivityWidgetSettingBinding
 import hsk.practice.myvoca.framework.toRoomVocabulary
 import hsk.practice.myvoca.module.RoomVocaRepository
@@ -27,25 +31,34 @@ class WidgetActivity : AppCompatActivity() {
 
     private var widgetId: Int = 0
 
+    private var textColor = 0
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         binding = ActivityWidgetSettingBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        binding.buttonClose.setOnClickListener {
-            closeActivity()
+        setColorPickerSize()
+        setProgressSize()
+
+        setColorPickerVisibility(View.VISIBLE)
+        setProgressVisibility(View.GONE)
+        setTextButtonVisibility(View.GONE)
+
+        binding.buttonClose.setOnClickListener { closeActivity() }
+        binding.imageColorPreview.setOnClickListener { showColorPicker() }
+        binding.buttonColorComplete.setOnClickListener {
+            setColorPickerVisibility(View.GONE)
+            showWidget()
         }
 
-        setProgressSize()
-        setProgressVisibility(View.VISIBLE)
-        setTextButtonVisibility(View.GONE)
+        textColor = ContextCompat.getColor(this, R.color.material_light_primary_text)
 
         widgetId = intent.getIntExtra(
             AppWidgetManager.EXTRA_APPWIDGET_ID,
             AppWidgetManager.INVALID_APPWIDGET_ID
         )
-        showWidget()
     }
 
     /**
@@ -80,12 +93,41 @@ class WidgetActivity : AppCompatActivity() {
         finish()
     }
 
+    private fun showColorPicker() {
+        ColorPickerDialogBuilder.with(this)
+            .setTitle("텍스트 색깔")
+            .initialColor(textColor)
+            .wheelType(ColorPickerView.WHEEL_TYPE.CIRCLE).density(10)
+            .setPositiveButton("확인") { _, lastSelectedColor, _ ->
+                textColor = lastSelectedColor
+                binding.imageColorPreview.setBackgroundColor(lastSelectedColor)
+            }
+            .setNegativeButton("취소") { _, _ -> }
+            .build()
+            .show()
+    }
+
+    private fun setColorPickerSize() {
+        val metrics = resources.displayMetrics
+        val params = binding.imageColorPreview.layoutParams
+        params.width = metrics.widthPixels / 2
+        params.height = metrics.widthPixels / 11
+    }
+
     private fun setProgressSize() {
         val metrics = resources.displayMetrics
         val size = min(metrics.widthPixels, metrics.heightPixels) / 2
         val params = binding.progressLoading.layoutParams
         params.width = size
         params.height = size
+    }
+
+    private fun setColorPickerVisibility(visibility: Int) {
+        with(binding) {
+            textColorPick.visibility = visibility
+            imageColorPreview.visibility = visibility
+            buttonColorComplete.visibility = visibility
+        }
     }
 
     private fun setProgressVisibility(visibility: Int) {

--- a/app/src/main/java/hsk/practice/myvoca/widget/WidgetActivity.kt
+++ b/app/src/main/java/hsk/practice/myvoca/widget/WidgetActivity.kt
@@ -22,24 +22,30 @@ class WidgetActivity : AppCompatActivity() {
     @Inject
     lateinit var vocaRepository: VocaRepository
 
+    private var widgetId: Int = 0
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
         binding = ActivityWidgetSettingBinding.inflate(layoutInflater)
         setContentView(binding.root)
 
-        val widgetId = intent.getIntExtra(
+        binding.buttonClose.setOnClickListener {
+            closeActivity()
+        }
+
+        widgetId = intent.getIntExtra(
             AppWidgetManager.EXTRA_APPWIDGET_ID,
             AppWidgetManager.INVALID_APPWIDGET_ID
         )
-        showWidget(widgetId)
+        showWidget()
     }
 
     /**
      * Widget configuration Activity가 정의되었으므로,
      * 위젯을 생성한 후 최초의 업데이트는 여기에서 수행해야 한다.
      */
-    private fun showWidget(widgetId: Int) = lifecycleScope.launch {
+    private fun showWidget() = lifecycleScope.launch {
         Logger.d("WidgetActivity showWidget()")
         val context = this@WidgetActivity
         val widgetManager = AppWidgetManager.getInstance(context)
@@ -49,7 +55,9 @@ class WidgetActivity : AppCompatActivity() {
             .also { remoteViews ->
                 widgetManager.updateAppWidget(widgetId, remoteViews)
             }
+    }
 
+    private fun closeActivity() {
         val result = Intent().apply {
             putExtra(AppWidgetManager.EXTRA_APPWIDGET_ID, widgetId)
         }

--- a/app/src/main/java/hsk/practice/myvoca/widget/WidgetActivity.kt
+++ b/app/src/main/java/hsk/practice/myvoca/widget/WidgetActivity.kt
@@ -3,6 +3,7 @@ package hsk.practice.myvoca.widget
 import android.appwidget.AppWidgetManager
 import android.content.Intent
 import android.os.Bundle
+import android.view.View
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.hsk.data.VocaRepository
@@ -11,8 +12,10 @@ import dagger.hilt.android.AndroidEntryPoint
 import hsk.practice.myvoca.databinding.ActivityWidgetSettingBinding
 import hsk.practice.myvoca.framework.toRoomVocabulary
 import hsk.practice.myvoca.module.RoomVocaRepository
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import javax.inject.Inject
+import kotlin.math.min
 
 @AndroidEntryPoint
 class WidgetActivity : AppCompatActivity() {
@@ -34,6 +37,10 @@ class WidgetActivity : AppCompatActivity() {
             closeActivity()
         }
 
+        setProgressSize()
+        setProgressVisibility(View.VISIBLE)
+        setTextButtonVisibility(View.GONE)
+
         widgetId = intent.getIntExtra(
             AppWidgetManager.EXTRA_APPWIDGET_ID,
             AppWidgetManager.INVALID_APPWIDGET_ID
@@ -46,15 +53,23 @@ class WidgetActivity : AppCompatActivity() {
      * 위젯을 생성한 후 최초의 업데이트는 여기에서 수행해야 한다.
      */
     private fun showWidget() = lifecycleScope.launch {
-        Logger.d("WidgetActivity showWidget()")
-        val context = this@WidgetActivity
-        val widgetManager = AppWidgetManager.getInstance(context)
+        val waitingJob = launch { delay(800L) }
+        launch {
+            Logger.d("WidgetActivity showWidget()")
+            val context = this@WidgetActivity
+            val widgetManager = AppWidgetManager.getInstance(context)
 
-        val vocabulary = vocaRepository.getRandomVocabulary()?.toRoomVocabulary() ?: return@launch
-        VocaWidgetProvider.remoteViewWithVocabulary(context, widgetId, vocabulary)
-            .also { remoteViews ->
-                widgetManager.updateAppWidget(widgetId, remoteViews)
-            }
+            val vocabulary =
+                vocaRepository.getRandomVocabulary()?.toRoomVocabulary()
+                    ?: throw IllegalStateException("Vocabulary is null!")
+            VocaWidgetProvider.remoteViewWithVocabulary(context, widgetId, vocabulary)
+                .also { remoteViews ->
+                    widgetManager.updateAppWidget(widgetId, remoteViews)
+                }
+            waitingJob.join()
+            setProgressVisibility(View.GONE)
+            setTextButtonVisibility(View.VISIBLE)
+        }
     }
 
     private fun closeActivity() {
@@ -63,5 +78,24 @@ class WidgetActivity : AppCompatActivity() {
         }
         setResult(RESULT_OK, result)
         finish()
+    }
+
+    private fun setProgressSize() {
+        val metrics = resources.displayMetrics
+        val size = min(metrics.widthPixels, metrics.heightPixels) / 2
+        val params = binding.progressLoading.layoutParams
+        params.width = size
+        params.height = size
+    }
+
+    private fun setProgressVisibility(visibility: Int) {
+        binding.progressLoading.visibility = visibility
+    }
+
+    private fun setTextButtonVisibility(visibility: Int) {
+        with(binding) {
+            textAdd.visibility = visibility
+            buttonClose.visibility = visibility
+        }
     }
 }

--- a/app/src/main/res/drawable/loading.xml
+++ b/app/src/main/res/drawable/loading.xml
@@ -1,0 +1,11 @@
+<layer-list
+    xmlns:android="http://schemas.android.com/apk/res/android">
+  <item android:gravity="center">
+    <rotate
+      android:drawable="@drawable/loading_outer"
+      android:pivotX="50%"
+      android:pivotY="50%"
+      android:fromDegrees="0"
+      android:toDegrees="360" />
+  </item>
+</layer-list>

--- a/app/src/main/res/drawable/loading_outer.xml
+++ b/app/src/main/res/drawable/loading_outer.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="ring"
+    android:thickness="2dp"
+    android:useLevel="false">
+    <gradient
+        android:angle="270"
+        android:centerColor="@color/colorPrimary"
+        android:endColor="@android:color/transparent"
+        android:startColor="@color/colorPrimary"
+        android:type="sweep" />
+</shape>

--- a/app/src/main/res/drawable/square.xml
+++ b/app/src/main/res/drawable/square.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/material_light_primary_text" />
+
+</shape>

--- a/app/src/main/res/layout/activity_widget_setting.xml
+++ b/app/src/main/res/layout/activity_widget_setting.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:app="http://schemas.android.com/apk/res-auto"
-    xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
@@ -8,7 +8,7 @@
         android:orientation="vertical">
 
         <TextView
-            android:id="@+id/textView2"
+            android:id="@+id/text_add"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
@@ -28,5 +28,18 @@
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
+
+        <ProgressBar
+            style="@style/Widget.AppCompat.ProgressBar"
+            android:id="@+id/progress_loading"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:indeterminateDrawable="@drawable/loading"
+            android:indeterminateDuration="1000"
+            app:layout_constraintBottom_toTopOf="@+id/button_close"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/activity_widget_setting.xml
+++ b/app/src/main/res/layout/activity_widget_setting.xml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android">
+<layout xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:android="http://schemas.android.com/apk/res/android">
 
-    <LinearLayout
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         android:orientation="vertical">
@@ -11,8 +12,21 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
-            android:layout_marginTop="150dp"
             android:text="@string/widget_setting_activity_message"
-            android:textSize="20sp" />
-    </LinearLayout>
+            android:textSize="20sp"
+            app:layout_constraintBottom_toTopOf="@+id/button_close"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <Button
+            android:id="@+id/button_close"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/close"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/layout/activity_widget_setting.xml
+++ b/app/src/main/res/layout/activity_widget_setting.xml
@@ -8,12 +8,45 @@
         android:orientation="vertical">
 
         <TextView
+            android:id="@+id/text_color_pick"
+            style="@style/LargeTextViewStyle"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/choose_text_color"
+            app:layout_constraintBottom_toTopOf="@+id/button_close"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <ImageView
+            android:id="@+id/image_color_preview"
+            android:layout_width="100dp"
+            android:layout_height="100dp"
+            android:background="@color/material_light_primary_text"
+            android:contentDescription="@string/description_choose_text_color"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <Button
+            android:id="@+id/button_color_complete"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/widget_margin"
+            android:text="@string/complete"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/image_color_preview" />
+
+        <TextView
             android:id="@+id/text_add"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_gravity="center_horizontal"
             android:text="@string/widget_setting_activity_message"
             android:textSize="20sp"
+            android:visibility="gone"
             app:layout_constraintBottom_toTopOf="@+id/button_close"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
@@ -24,18 +57,20 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:text="@string/close"
+            android:visibility="gone"
             app:layout_constraintBottom_toBottomOf="parent"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
         <ProgressBar
-            style="@style/Widget.AppCompat.ProgressBar"
             android:id="@+id/progress_loading"
+            style="@style/Widget.AppCompat.ProgressBar"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:indeterminateDrawable="@drawable/loading"
             android:indeterminateDuration="1000"
+            android:visibility="gone"
             app:layout_constraintBottom_toTopOf="@+id/button_close"
             app:layout_constraintEnd_toEndOf="parent"
             app:layout_constraintStart_toStartOf="parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -82,4 +82,7 @@
     <string name="word_english">word</string>
     <string name="word_korean">단어</string>
     <string name="close">닫기</string>
+    <string name="choose_text_color">위젯의 텍스트 색깔을 선택해 주세요.</string>
+    <string name="complete">완료</string>
+    <string name="description_choose_text_color">위젯의 텍스트 색깔을 선택한다.</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -81,4 +81,5 @@
     <string name="zero">0</string>
     <string name="word_english">word</string>
     <string name="word_korean">단어</string>
+    <string name="close">닫기</string>
 </resources>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -57,6 +57,10 @@
         <item name="android:textSize">18sp</item>
     </style>
 
+    <style name="LargeTextViewStyle">
+        <item name="android:textSize">22sp</item>
+    </style>
+
     <style name="QuizTextStyle">
         <item name="android:textSize">40sp</item>
         <item name="fontFamily">@font/maplestory_bold</item>

--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
         lifecycle_extension_version = '2.2.0'
         room_version = '2.3.0'
         hilt_version = '2.35.1'
+        datastore_version = '1.0.0-beta01'
     }
     repositories {
         google()

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ allprojects {
     repositories {
         google()
         mavenCentral()
+        maven { url 'https://jitpack.io' }
     }
 }
 


### PR DESCRIPTION
## 위젯의 텍스트 색깔을 설정할 수 있음 (Closes #32)
### 텍스트 색깔 설정
위젯을 홈 화면에 추가할 때 텍스트의 색깔을 선택할 수 있다. 색깔은 [Color Picker](https://github.com/QuadFlask/colorpicker)를 이용하여 선택하며, 선택한 색깔은 ``DataStore``에 저장된다.

위젯을 업데이트할 때마다 ``DataStore``에서 색깔 정보를 가져와 위젯에 반영한다.