### PR TITLE
RecyclerView에 스크롤 바 추가

### DIFF
--- a/app/src/main/res/drawable/line.xml
+++ b/app/src/main/res/drawable/line.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <solid android:color="@color/light_grey" />
+    <padding
+        android:bottom="@dimen/widget_margin"
+        android:left="@dimen/widget_margin"
+        android:right="@dimen/widget_margin"
+        android:top="@dimen/widget_margin" />
+
+</shape>

--- a/app/src/main/res/drawable/line_drawable.xml
+++ b/app/src/main/res/drawable/line_drawable.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/line" android:state_pressed="true" />
+    <item android:drawable="@drawable/line" />
+
+</selector>

--- a/app/src/main/res/drawable/thumb.xml
+++ b/app/src/main/res/drawable/thumb.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<shape xmlns:android="http://schemas.android.com/apk/res/android">
+    <corners android:radius="44dp" />
+    <padding
+        android:left="22dp"
+        android:right="22dp" />
+    <solid android:color="@color/quantum_grey_600" />
+</shape>

--- a/app/src/main/res/drawable/thumb_drawable.xml
+++ b/app/src/main/res/drawable/thumb_drawable.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<selector xmlns:android="http://schemas.android.com/apk/res/android">
+    <item android:drawable="@drawable/thumb" android:state_pressed="true" />
+    <item android:drawable="@drawable/thumb" />
+</selector>

--- a/app/src/main/res/layout/fragment_see_all.xml
+++ b/app/src/main/res/layout/fragment_see_all.xml
@@ -85,7 +85,11 @@
             android:layout_height="0dp"
             android:layout_weight="1"
             android:orientation="vertical"
-            android:scrollbars="vertical">
+            app:fastScrollEnabled="true"
+            app:fastScrollHorizontalThumbDrawable="@drawable/thumb_drawable"
+            app:fastScrollHorizontalTrackDrawable="@drawable/line_drawable"
+            app:fastScrollVerticalThumbDrawable="@drawable/thumb_drawable"
+            app:fastScrollVerticalTrackDrawable="@drawable/line_drawable">
 
         </androidx.recyclerview.widget.RecyclerView>
 

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -12,6 +12,7 @@
     <color name="active_icon_color">#8A000000</color>
     <color name="cards_and_dialogs_color">@color/material_light_primary_text</color>
     <color name="quantum_grey_600">#757575</color>
+    <color name="light_grey">#A0A0A0</color>
 
     <color name="bg_row_background">#FA315B</color>
     <color name="bg_row_foreground">#FAFAFA</color>


### PR DESCRIPTION
## 스크롤 바 추가 (Closes #28)
XML 레이아웃에서 다음을 추가한다.
```
<androidx.recyclerview.widget.RecyclerView
    ...
    app:fastScrollEnabled="true"
    app:fastScrollHorizontalThumbDrawable="@drawable/thumb_drawable"
    app:fastScrollHorizontalTrackDrawable="@drawable/line_drawable"
    app:fastScrollVerticalThumbDrawable="@drawable/thumb_drawable"
    app:fastScrollVerticalTrackDrawable="@drawable/line_drawable">
```
* ThumbDrawable: 터치하여 움직일 수 있는 **바 (bar)**.
* TrackDrawable: ``ThumbDrawable``이 움직이는 길이다.
### [Android API 이슈](https://issuetracker.google.com/issues/64729576)
하지만 데이터가 많아지면 ``Thumb``가 너무 작아지는 문제가 있다. 이것은 Android API의 문제이므로 내가 할 수 있는 일은 없다.