### PR TITLE
VocaRecyclerViewAdapter 리팩토링

### DIFF
--- a/app/src/main/java/hsk/practice/myvoca/AppHelper.kt
+++ b/app/src/main/java/hsk/practice/myvoca/AppHelper.kt
@@ -49,7 +49,7 @@ object AppHelper {
                 e.printStackTrace()
             }
         }
-        val timeString = getTimeString(System.currentTimeMillis())
+        val timeString = System.currentTimeMillis().getTimeString()
         try {
             val bw = BufferedWriter(FileWriter(logFile, true))
             bw.append("$timeString: $text")
@@ -58,24 +58,6 @@ object AppHelper {
         } catch (e: IOException) {
             e.printStackTrace()
         }
-    }
-
-    /**
-     * Returns a time-formatted string by the given timestamp.
-     *
-     * @param timeInMillis Unix epoch timestamp to convert to string
-     * @return Time string of the timestamp
-     */
-    fun getTimeString(timeInMillis: Long): String {
-        val cal = Calendar.getInstance()
-        cal.timeInMillis = timeInMillis
-        val year = cal[Calendar.YEAR]
-        val mon = cal[Calendar.MONTH]
-        val day = cal[Calendar.DAY_OF_MONTH]
-        val hour = cal[Calendar.HOUR_OF_DAY]
-        val min = cal[Calendar.MINUTE]
-        val sec = cal[Calendar.SECOND]
-        return String.format("%d.%02d.%02d. %02d:%02d:%02d", year, mon + 1, day, hour, min, sec)
     }
 
     /**

--- a/app/src/main/java/hsk/practice/myvoca/extensions.kt
+++ b/app/src/main/java/hsk/practice/myvoca/extensions.kt
@@ -4,10 +4,7 @@ import android.content.Context
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.preferencesDataStore
-import androidx.lifecycle.LiveData
-import androidx.lifecycle.Observer
-import java.util.concurrent.CountDownLatch
-import java.util.concurrent.TimeUnit
+import java.util.*
 
 /**
  * Preferences DataStore object. Delegated by preferenceDataStore().
@@ -31,15 +28,19 @@ fun String?.containsOnlyAlphabet(): Boolean {
 }
 
 
-@Throws(Exception::class)
-fun <T> LiveData<T>.getValueBlocking(): T {
-    var value: T? = null
-    val latch = CountDownLatch(1)
-    val innerObserver = Observer<T> {
-        value = it
-        latch.countDown()
-    }
-    observeForever(innerObserver)
-    latch.await(10, TimeUnit.SECONDS)
-    return value ?: throw IllegalStateException("Value not set")
+/**
+ * Returns a time-formatted string by the given timestamp.
+ *
+ * @return Time string of the timestamp
+ */
+fun Long.getTimeString(): String {
+    val cal = Calendar.getInstance()
+    cal.timeInMillis = this
+    val year = cal[Calendar.YEAR]
+    val mon = cal[Calendar.MONTH]
+    val day = cal[Calendar.DAY_OF_MONTH]
+    val hour = cal[Calendar.HOUR_OF_DAY]
+    val min = cal[Calendar.MINUTE]
+    val sec = cal[Calendar.SECOND]
+    return String.format("%d.%02d.%02d. %02d:%02d:%02d", year, mon + 1, day, hour, min, sec)
 }

--- a/app/src/main/java/hsk/practice/myvoca/framework/VocaPersistenceDatabase.kt
+++ b/app/src/main/java/hsk/practice/myvoca/framework/VocaPersistenceDatabase.kt
@@ -73,7 +73,7 @@ class VocaPersistenceDatabase @Inject constructor(@ApplicationContext context: C
 
     override suspend fun getVocabulary(query: String): List<Vocabulary?>? {
         return if (query.containsOnlyAlphabet()) {
-            vocaDao.loadVocabularyByEng(query)
+            vocaDao.loadVocabularyByEng("%${query}%")
         } else {
             vocaDao.loadVocabularyByKor(query)
         }?.toVocabularyList()

--- a/app/src/main/java/hsk/practice/myvoca/ui/quiz/QuizAdapter.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/quiz/QuizAdapter.kt
@@ -14,18 +14,33 @@ import hsk.practice.myvoca.framework.RoomVocabulary
 import hsk.practice.myvoca.ui.seeall.recyclerview.RoomVocabularyDiffCallback
 
 class QuizAdapter(private val onClick: (position: Int) -> Unit) :
-    ListAdapter<RoomVocabulary, QuizViewHolder>(RoomVocabularyDiffCallback()) {
+    ListAdapter<RoomVocabulary, QuizAdapter.QuizViewHolder>(RoomVocabularyDiffCallback()) {
 
-    private val onItemClicked = { position: Int ->
-        onClick.invoke(position)
+    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QuizViewHolder {
+        val inflater = LayoutInflater.from(parent.context)
+        val binding = QuizItemBinding.inflate(inflater, parent, false)
+        return QuizViewHolder(binding, onClick)
     }
-
-    override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): QuizViewHolder =
-        QuizViewHolder.from(parent, onClick)
 
     override fun onBindViewHolder(holder: QuizViewHolder, position: Int) {
         val item = getItem(position)
-        holder.bind(item, position)
+        holder.bind(item)
+    }
+
+    inner class QuizViewHolder(
+        private val binding: QuizItemBinding,
+        private val onClicked: (position: Int) -> Unit
+    ) : RecyclerView.ViewHolder(binding.root) {
+
+        init {
+            binding.root.setOnClickListener {
+                onClicked(absoluteAdapterPosition)
+            }
+        }
+
+        fun bind(quizOption: RoomVocabulary) {
+            binding.quizOption = quizOption
+        }
     }
 
 }
@@ -48,26 +63,6 @@ class ItemDecoration(private var size: Int) : RecyclerView.ItemDecoration() {
     }
 }
 
-class QuizViewHolder private constructor(
-    private val binding: QuizItemBinding,
-    private val onClicked: (position: Int) -> Unit
-) : RecyclerView.ViewHolder(binding.root) {
-
-    companion object {
-        fun from(parent: ViewGroup, onItemClicked: (position: Int) -> Unit): QuizViewHolder {
-            val layoutInflater = LayoutInflater.from(parent.context)
-            val binding = QuizItemBinding.inflate(layoutInflater, parent, false)
-            return QuizViewHolder(binding, onItemClicked)
-        }
-    }
-
-    fun bind(quizOption: RoomVocabulary, position: Int) {
-        binding.root.setOnClickListener {
-            onClicked(position)
-        }
-        binding.quizOption = quizOption
-    }
-}
 
 @BindingAdapter("quizOption")
 fun TextView.bindQuiz(quizOption: RoomVocabulary) {

--- a/app/src/main/java/hsk/practice/myvoca/ui/seeall/SeeAllFragment.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/seeall/SeeAllFragment.kt
@@ -139,7 +139,7 @@ class SeeAllFragment : Fragment(), VocabularyTouchHelperListener {
         // Load adapter asynchronously
         lifecycleScope.launch(Dispatchers.IO) {
             vocaAdapter =
-                VocaRecyclerViewAdapter(seeAllViewModel, seeAllViewModel.menuItemClickListener)
+                VocaRecyclerViewAdapter(seeAllViewModel.deleteData, seeAllViewModel.itemListener)
             vocaRecyclerView.adapter = vocaAdapter
         }
 
@@ -167,7 +167,7 @@ class SeeAllFragment : Fragment(), VocabularyTouchHelperListener {
         // what to do when update request is given
         seeAllViewModel.eventVocabularyUpdateRequest.observe(viewLifecycleOwner) { position ->
             position?.let {
-                val target = seeAllViewModel.currentVocabulary.value?.get(position)
+                val target = seeAllViewModel.getCurrentVocabulary(position)
                 Logger.d("Update: $target")
                 val intent = Intent(context, EditVocaActivity::class.java)
                 intent.putExtra(Constants.POSITION, position)
@@ -240,7 +240,7 @@ class SeeAllFragment : Fragment(), VocabularyTouchHelperListener {
         (searchMenuItem.actionView as SearchView).setOnQueryTextListener(object :
             SearchView.OnQueryTextListener {
             override fun onQueryTextSubmit(query: String?): Boolean {
-                query?.let { searchVocabulary(it) }
+                query?.let { seeAllViewModel.searchVocabulary(it) }
                 return false
             }
 
@@ -267,15 +267,6 @@ class SeeAllFragment : Fragment(), VocabularyTouchHelperListener {
             dialog.show()
         }
         deleteCancelButton.setOnClickListener { seeAllViewModel.onDeleteModeChange(false) }
-    }
-
-    /**
-     * Search the vocabulary and show the result
-     *
-     * @param query query string to search, only english supported.
-     */
-    private fun searchVocabulary(query: String) {
-        seeAllViewModel.searchVocabulary(query)
     }
 
     /**
@@ -382,6 +373,7 @@ class SeeAllFragment : Fragment(), VocabularyTouchHelperListener {
         return resources?.configuration?.layoutDirection == View.LAYOUT_DIRECTION_RTL
     }
 
+    // TODO: back key when delete mode is enabled
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
         view.isFocusableInTouchMode = true

--- a/app/src/main/java/hsk/practice/myvoca/ui/seeall/SeeAllFragment.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/seeall/SeeAllFragment.kt
@@ -443,11 +443,11 @@ class SeeAllFragment : Fragment(), VocabularyTouchHelperListener {
                     position: Int,
                     id: Long
                 ) {
-                    seeAllViewModel.setSortState(position)
+                    seeAllViewModel.setSortState(SortMethod.get(position)!!)
                 }
 
                 override fun onNothingSelected(parent: AdapterView<*>?) {
-                    seeAllViewModel.setSortState(0)
+                    seeAllViewModel.setSortState(SortMethod.ENG)
                 }
             }
             setSelection(0)

--- a/app/src/main/java/hsk/practice/myvoca/ui/seeall/SeeAllFragment.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/seeall/SeeAllFragment.kt
@@ -183,11 +183,11 @@ class SeeAllFragment : Fragment(), VocabularyTouchHelperListener {
             mode?.let {
                 if (mode) {
                     deleteLayout.visibility = View.VISIBLE
-                    vocaRecyclerViewAdapter.notifyItemsChanged()
                 } else {
                     deleteLayout.visibility = View.GONE
-                    vocaRecyclerViewAdapter.clearSelectedState()
+                    seeAllViewModel.clearSelectedItems()
                 }
+                vocaRecyclerViewAdapter.notifyItemsChanged()
                 seeAllViewModel.onDeleteModeUpdateComplete()
             }
         }
@@ -251,17 +251,16 @@ class SeeAllFragment : Fragment(), VocabularyTouchHelperListener {
         })
     }
 
-    // TODO: ViewModel should have responsibility of deleting vocabulary, not RecyclerView.Adapter
     private fun setDeleteButtonListener() {
         // Delete one or many items (with checkbox)
         deleteVocabularyButton.setOnClickListener {
-            val selectedItems = vocaRecyclerViewAdapter.getSelectedItems()
+            val selectedItemsCount = seeAllViewModel.getSelectedCount()
             val dialog = AlertDialog.Builder(parentActivity).apply {
                 setTitle("삭제")
-                setMessage("${selectedItems.size}개의 단어를 삭제합니다.")
+                setMessage("${selectedItemsCount}개의 단어를 삭제합니다.")
                 setIcon(android.R.drawable.ic_dialog_alert)
                 setPositiveButton("확인") { _, _ ->
-                    vocaRecyclerViewAdapter.deleteVocabularies()
+                    seeAllViewModel.deleteSelectedItems()
                     seeAllViewModel.onDeleteModeChange(false)
                 }
                 setNegativeButton("취소") { _, _ -> }
@@ -277,7 +276,7 @@ class SeeAllFragment : Fragment(), VocabularyTouchHelperListener {
      * @param query query string to search, only english supported.
      */
     private fun searchVocabulary(query: String) {
-        vocaRecyclerViewAdapter.searchVocabulary(query)
+        seeAllViewModel.searchVocabulary(query)
     }
 
     /**

--- a/app/src/main/java/hsk/practice/myvoca/ui/seeall/SeeAllViewModel.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/seeall/SeeAllViewModel.kt
@@ -13,6 +13,7 @@ import hsk.practice.myvoca.framework.toRoomVocabularyList
 import hsk.practice.myvoca.framework.toRoomVocabularyMutableList
 import hsk.practice.myvoca.framework.toVocabulary
 import hsk.practice.myvoca.module.RoomVocaRepository
+import hsk.practice.myvoca.ui.seeall.recyclerview.VocaRecyclerViewAdapter
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -216,4 +217,38 @@ class SeeAllViewModel @Inject constructor(@RoomVocaRepository private val vocaRe
 
     fun getSelectedCount() = selectedItems.size
 
+    val menuItemClickListener = object : VocaRecyclerViewAdapter.OnMenuItemClickListener {
+        override fun onClick(itemId: Int, position: Int) {
+            when (MenuCode.get(itemId)) {
+                MenuCode.EDIT -> {
+                    onVocabularyUpdate(position)
+                }
+                MenuCode.DELETE -> {
+                    onDeleteModeChange(true)
+                    switchSelectedState(position)
+                }
+                MenuCode.SHOW_ON_NOTIFICATION -> {
+                    val vocabulary = getCurrentVocabulary(position)
+                    vocabulary?.let { onShowVocabulary(it) }
+                }
+                else -> Logger.d("MenuItemClick Else")
+            }
+        }
+    }
+
+}
+
+/**
+ * Menu item code in RecyclerView.
+ * Assigned one-by-one for each menu item.
+ */
+enum class MenuCode(val value: Int) {
+    EDIT(0),
+    DELETE(1),
+    SHOW_ON_NOTIFICATION(2);
+
+    companion object {
+        private val VALUES = values()
+        fun get(value: Int) = VALUES.firstOrNull { it.value == value }
+    }
 }

--- a/app/src/main/java/hsk/practice/myvoca/ui/seeall/SeeAllViewModel.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/seeall/SeeAllViewModel.kt
@@ -82,6 +82,11 @@ class SeeAllViewModel @Inject constructor(@RoomVocaRepository private val vocaRe
         }
     }
 
+    /**
+     * Searches the vocabulary with a given query.
+     *
+     * @param query String to search with. [query] should not include % character.
+     */
     fun searchVocabulary(query: String) = viewModelScope.launch(Dispatchers.IO) {
         val result = vocaRepository.getVocabulary(query) ?: return@launch
         val sortedResult = sortItems(result, sortState.value!!)
@@ -179,5 +184,36 @@ class SeeAllViewModel @Inject constructor(@RoomVocaRepository private val vocaRe
     fun onShowVocabularyComplete() {
         _eventShowVocabulary.value = null
     }
+
+    /**
+     * Data for RecyclerView.
+     *
+     * Manages selected items in a RecyclerView when delete mode is enabled.
+     */
+    private val selectedItems = mutableSetOf<Int>()
+
+    fun isSelected(position: Int) = selectedItems.contains(position)
+
+    fun switchSelectedState(position: Int) {
+        if (selectedItems.contains(position)) {
+            selectedItems.remove(position)
+        } else {
+            selectedItems.add(position)
+        }
+    }
+
+    fun clearSelectedItems() {
+        selectedItems.clear()
+    }
+
+    fun deleteSelectedItems() {
+        deleteItems(selectedItems.toList())
+    }
+
+    fun getSelectedItems() = selectedItems
+
+    fun getSelectedItemsList(): List<Int> = selectedItems.toList()
+
+    fun getSelectedCount() = selectedItems.size
 
 }

--- a/app/src/main/java/hsk/practice/myvoca/ui/seeall/recyclerview/VocaRecyclerViewAdapter.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/seeall/recyclerview/VocaRecyclerViewAdapter.kt
@@ -1,18 +1,15 @@
 package hsk.practice.myvoca.ui.seeall.recyclerview
 
-import android.os.*
 import android.view.*
-import android.view.ContextMenu.ContextMenuInfo
-import android.view.View.OnCreateContextMenuListener
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import hsk.practice.myvoca.databinding.VocaViewBinding
 import hsk.practice.myvoca.framework.RoomVocabulary
 import hsk.practice.myvoca.getTimeString
+import hsk.practice.myvoca.ui.seeall.MenuCode
 import hsk.practice.myvoca.ui.seeall.SeeAllViewModel
 import hsk.practice.myvoca.ui.seeall.recyclerview.VocaRecyclerViewAdapter.VocaViewHolder
-import java.util.*
 
 /**
  * RecyclerAdapter for each vocabulary.
@@ -20,8 +17,24 @@ import java.util.*
  *
  * For further information, Please refer the comments above some methods.
  */
-class VocaRecyclerViewAdapter(val viewModel: SeeAllViewModel) :
+class VocaRecyclerViewAdapter(
+    val viewModel: SeeAllViewModel,
+    private val menuItemClickListener: OnMenuItemClickListener
+) :
     ListAdapter<RoomVocabulary, VocaViewHolder>(RoomVocabularyDiffCallback()) {
+
+    /**
+     * Menu item click listener for each item in RecyclerView.
+     */
+    interface OnMenuItemClickListener {
+        /**
+         * Callback invoked when each menu item is clicked
+         *
+         * @param itemId Id of the menu item
+         * @param position Position of the RecyclerView item
+         */
+        fun onClick(itemId: Int, position: Int)
+    }
 
     val deleteMode: Boolean
         get() = viewModel.deleteMode.value!!
@@ -30,12 +43,10 @@ class VocaRecyclerViewAdapter(val viewModel: SeeAllViewModel) :
         val vocaBinding =
             VocaViewBinding.inflate(LayoutInflater.from(parent.context), parent, false)
 
-        // TODO: replace to companion object method VocaViewHolder.from(...)
-        val holder = VocaViewHolder(vocaBinding)
+        val holder = VocaViewHolder(vocaBinding, menuItemClickListener)
         return holder
     }
 
-    // Bind the content to the item
     override fun onBindViewHolder(holder: VocaViewHolder, position: Int) {
         val vocabulary = getItem(position) ?: RoomVocabulary.nullVocabulary
         holder.bind(vocabulary, viewModel.isSelected(position))
@@ -49,56 +60,47 @@ class VocaRecyclerViewAdapter(val viewModel: SeeAllViewModel) :
      * ViewHolder for vocabulary object.
      * Manages the content of the item and action when the item is clicked or long-clicked.
      */
-    inner class VocaViewHolder(private val vocaBinding: VocaViewBinding) :
-        RecyclerView.ViewHolder(vocaBinding.root), OnCreateContextMenuListener {
-
-        private val EDIT_CODE = 100
-        private val DELETE_CODE = 101
-        private val SHOW_ON_NOTIFICATION_CODE = 102
+    inner class VocaViewHolder(
+        private val vocaBinding: VocaViewBinding,
+        private val onMenuItemClickListener: OnMenuItemClickListener
+    ) : RecyclerView.ViewHolder(vocaBinding.root) {
 
         var viewForeground = vocaBinding.viewForeground
         var viewBackground = vocaBinding.viewBackground
 
-        // long-click listener
-        private val onMenuItemClickListener: MenuItem.OnMenuItemClickListener =
-            MenuItem.OnMenuItemClickListener { item ->
-                val position = layoutPosition
-                // val position = adapterPosition
-                val vocabulary = viewModel.currentVocabulary.value?.get(position)
-                    ?: return@OnMenuItemClickListener true
-                when (item.itemId) {
-                    EDIT_CODE -> {
-//                    onVocabularyUpdateListener?.updateVocabulary(position)
-                        viewModel.onVocabularyUpdate(position)
-                    }
-                    DELETE_CODE -> {
-                        viewModel.onDeleteModeChange(true)
-                        viewModel.switchSelectedState(position)
-                    }
-                    SHOW_ON_NOTIFICATION_CODE -> {
-                        // TODO: show selected vocabulary on notification
-                        viewModel.onShowVocabulary(vocabulary)
-                    }
-                }
-                true
-            }
+        val realMenuItemClickListener = MenuItem.OnMenuItemClickListener { item ->
+            onMenuItemClickListener.onClick(item.itemId, absoluteAdapterPosition)
+            true
+        }
 
-        // Create drop-down menu when item is long-clicked
-        override fun onCreateContextMenu(menu: ContextMenu?, v: View?, menuInfo: ContextMenuInfo?) {
-            if (viewModel.deleteMode.value == true) {
-                return
+        init {
+            vocaBinding.root.setOnClickListener {
+                if (deleteMode) {
+                    val position = absoluteAdapterPosition
+                    viewModel.switchSelectedState(position)
+                    notifyItemChanged(position)
+                }
             }
-            val edit = menu?.add(Menu.NONE, EDIT_CODE, 1, "수정")
-            val delete = menu?.add(Menu.NONE, DELETE_CODE, 2, "삭제")
-            //            MenuItem showOnNotification = menu.add(Menu.NONE, SHOW_ON_NOTIFICATION_CODE, 3, "알림에 보이기");
-            edit?.setOnMenuItemClickListener(onMenuItemClickListener)
-            delete?.setOnMenuItemClickListener(onMenuItemClickListener)
-            //            showOnNotification.setOnMenuItemClickListener(onMenuItemClickListener);
+            /* Create Context pop-up menu when long clicked */
+            vocaBinding.root.setOnCreateContextMenuListener { contextMenu, view, contextMenuInfo ->
+                if (deleteMode) {
+                    return@setOnCreateContextMenuListener
+                }
+                contextMenu?.add(Menu.NONE, MenuCode.EDIT.value, 1, "수정")?.apply {
+                    setOnMenuItemClickListener(realMenuItemClickListener)
+                }
+                contextMenu?.add(Menu.NONE, MenuCode.DELETE.value, 2, "삭제")?.apply {
+                    setOnMenuItemClickListener(realMenuItemClickListener)
+                }
+                contextMenu?.add(Menu.NONE, MenuCode.SHOW_ON_NOTIFICATION.value, 3, "알림에 보이기")
+                    ?.apply {
+                        setOnMenuItemClickListener(realMenuItemClickListener)
+                    }
+            }
         }
 
         fun bind(vocabulary: RoomVocabulary, isChecked: Boolean) {
             setVocabulary(vocabulary)
-//            this@VocaRecyclerViewAdapter.vocaClickListener = vocaClickListener
             if (vocabulary != RoomVocabulary.nullVocabulary) {
                 setDeleteCheckBox(isChecked)
             }
@@ -122,17 +124,6 @@ class VocaRecyclerViewAdapter(val viewModel: SeeAllViewModel) :
                     isChecked = false
                 }
             }
-        }
-
-        init {
-            vocaBinding.root.setOnClickListener {
-                if (deleteMode) {
-                    val position = absoluteAdapterPosition
-                    viewModel.switchSelectedState(position)
-                    notifyItemChanged(position)
-                }
-            }
-            vocaBinding.root.setOnCreateContextMenuListener(this)
         }
     }
 }

--- a/app/src/main/java/hsk/practice/myvoca/ui/seeall/recyclerview/VocaRecyclerViewAdapter.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/seeall/recyclerview/VocaRecyclerViewAdapter.kt
@@ -177,7 +177,7 @@ class VocaRecyclerViewAdapter(val viewModel: SeeAllViewModel) :
 
         init {
             vocaBinding.root.setOnClickListener {
-                switchSelectedState(adapterPosition)
+                switchSelectedState(absoluteAdapterPosition)
             }
             vocaBinding.root.setOnCreateContextMenuListener(this)
         }

--- a/app/src/main/java/hsk/practice/myvoca/ui/seeall/recyclerview/VocaRecyclerViewAdapter.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/seeall/recyclerview/VocaRecyclerViewAdapter.kt
@@ -13,6 +13,7 @@ import hsk.practice.myvoca.AppHelper
 import hsk.practice.myvoca.databinding.VocaViewBinding
 import hsk.practice.myvoca.framework.RoomVocabulary
 import hsk.practice.myvoca.ui.seeall.SeeAllViewModel
+import hsk.practice.myvoca.ui.seeall.SortMethod
 import hsk.practice.myvoca.ui.seeall.recyclerview.VocaRecyclerViewAdapter.VocaViewHolder
 import java.util.*
 
@@ -90,7 +91,7 @@ class VocaRecyclerViewAdapter(val viewModel: SeeAllViewModel)
     }
 
     fun sortItems(method: Int) {
-        viewModel.setSortState(method)
+        viewModel.setSortState(SortMethod.get(method)!!)
     }
 
     /**

--- a/app/src/main/java/hsk/practice/myvoca/ui/seeall/recyclerview/VocaRecyclerViewAdapter.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/seeall/recyclerview/VocaRecyclerViewAdapter.kt
@@ -9,9 +9,9 @@ import androidx.core.util.keyIterator
 import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
-import hsk.practice.myvoca.AppHelper
 import hsk.practice.myvoca.databinding.VocaViewBinding
 import hsk.practice.myvoca.framework.RoomVocabulary
+import hsk.practice.myvoca.getTimeString
 import hsk.practice.myvoca.ui.seeall.SeeAllViewModel
 import hsk.practice.myvoca.ui.seeall.SortMethod
 import hsk.practice.myvoca.ui.seeall.recyclerview.VocaRecyclerViewAdapter.VocaViewHolder
@@ -23,8 +23,8 @@ import java.util.*
  *
  * For further information, Please refer the comments above some methods.
  */
-class VocaRecyclerViewAdapter(val viewModel: SeeAllViewModel)
-    : ListAdapter<RoomVocabulary, VocaViewHolder>(RoomVocabularyDiffCallback()) {
+class VocaRecyclerViewAdapter(val viewModel: SeeAllViewModel) :
+    ListAdapter<RoomVocabulary, VocaViewHolder>(RoomVocabularyDiffCallback()) {
 
     val deleteMode: Boolean
         get() = viewModel.deleteMode.value!!
@@ -34,7 +34,8 @@ class VocaRecyclerViewAdapter(val viewModel: SeeAllViewModel)
     private val selectedItems: SparseBooleanArray = SparseBooleanArray()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): VocaViewHolder {
-        val vocaBinding = VocaViewBinding.inflate(LayoutInflater.from(parent.context), parent, false)
+        val vocaBinding =
+            VocaViewBinding.inflate(LayoutInflater.from(parent.context), parent, false)
 
         // TODO: replace to companion object method VocaViewHolder.from(...)
         val holder = VocaViewHolder(vocaBinding)
@@ -98,8 +99,8 @@ class VocaRecyclerViewAdapter(val viewModel: SeeAllViewModel)
      * ViewHolder for vocabulary object.
      * Manages the content of the item and action when the item is clicked or long-clicked.
      */
-    inner class VocaViewHolder(private val vocaBinding: VocaViewBinding)
-        : RecyclerView.ViewHolder(vocaBinding.root), OnCreateContextMenuListener {
+    inner class VocaViewHolder(private val vocaBinding: VocaViewBinding) :
+        RecyclerView.ViewHolder(vocaBinding.root), OnCreateContextMenuListener {
 
         private val EDIT_CODE = 100
         private val DELETE_CODE = 101
@@ -109,28 +110,29 @@ class VocaRecyclerViewAdapter(val viewModel: SeeAllViewModel)
         var viewBackground = vocaBinding.viewBackground
 
         // long-click listener
-        private val onMenuItemClickListener: MenuItem.OnMenuItemClickListener = MenuItem.OnMenuItemClickListener { item ->
-            val position = layoutPosition
-            // val position = adapterPosition
-            val vocabulary = viewModel.currentVocabulary.value?.get(position)
+        private val onMenuItemClickListener: MenuItem.OnMenuItemClickListener =
+            MenuItem.OnMenuItemClickListener { item ->
+                val position = layoutPosition
+                // val position = adapterPosition
+                val vocabulary = viewModel.currentVocabulary.value?.get(position)
                     ?: return@OnMenuItemClickListener true
-            when (item.itemId) {
-                EDIT_CODE -> {
+                when (item.itemId) {
+                    EDIT_CODE -> {
 //                    onVocabularyUpdateListener?.updateVocabulary(position)
-                    viewModel.onVocabularyUpdate(position)
+                        viewModel.onVocabularyUpdate(position)
+                    }
+                    DELETE_CODE -> {
+                        val adapter = this@VocaRecyclerViewAdapter
+                        viewModel.onDeleteModeChange(true)
+                        adapter.switchSelectedState(position)
+                    }
+                    SHOW_ON_NOTIFICATION_CODE -> {
+                        // TODO: show selected vocabulary on notification
+                        viewModel.onShowVocabulary(vocabulary)
+                    }
                 }
-                DELETE_CODE -> {
-                    val adapter = this@VocaRecyclerViewAdapter
-                    viewModel.onDeleteModeChange(true)
-                    adapter.switchSelectedState(position)
-                }
-                SHOW_ON_NOTIFICATION_CODE -> {
-                    // TODO: show selected vocabulary on notification
-                    viewModel.onShowVocabulary(vocabulary)
-                }
+                true
             }
-            true
-        }
 
         // Create drop-down menu when item is long-clicked
         override fun onCreateContextMenu(menu: ContextMenu?, v: View?, menuInfo: ContextMenuInfo?) {
@@ -157,7 +159,7 @@ class VocaRecyclerViewAdapter(val viewModel: SeeAllViewModel)
             vocabulary?.apply {
                 vocaBinding.vocaEng.text = eng
                 vocaBinding.vocaKor.text = kor
-                vocaBinding.lastEditTime.text = AppHelper.getTimeString(lastEditedTime * 1000)
+                vocaBinding.lastEditTime.text = (lastEditedTime * 1000).getTimeString()
             }
         }
 


### PR DESCRIPTION
## 정렬 방법을 enum으로 정의
``VocaRecyclerViewAdapter``는 정렬 방법에 대한 어떤 정보도 알지 못하며, 오로지 주어지는 데이터를 보여주기만 한다. 정렬 방법은``SeeAllViewModel``에서 관리한다.
```
enum class SortMethod(val value: Int) {
    ENG(0),
    EDITED_TIME(1);
}
````
## ``Adapter``와 ``ViewHolder``의 모든 의존성을 외부에서 주입받도록 수정
``VocaRecyclerViewAdapter``에서 사용되는 모든 의존성을 외부에서 주입받는다. 주입받는 의존성은 다음과 같다.
* ``interface DeleteData``: 삭제 모드에 관련된 데이터
* ``interface ItemListener``: 각 item에서 사용되는 리스너의 모음

``VocaRecyclerView``를 포함하는 상위 뷰 쪽에서 의존성을 제공해야 한다. ``SeeAllFragment``에서는 ``SeeAllViewModel``이 의존성을 제공한다.