### PR TITLE
fix: 뒤로 가기 버튼으로 삭제 모드를 빠져나갈 수 없는 버그 수정

### DIFF
--- a/app/src/main/java/hsk/practice/myvoca/ui/seeall/SeeAllViewModel.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/seeall/SeeAllViewModel.kt
@@ -165,7 +165,7 @@ class SeeAllViewModel @Inject constructor(@RoomVocaRepository private val vocaRe
     val eventDeleteModeChanged: LiveData<Boolean?>
         get() = _eventDeleteModeChanged
 
-    fun onDeleteModeChange(mode: Boolean) {
+    fun changeDeleteMode(mode: Boolean) {
         _eventDeleteModeChanged.value = mode
         _deleteMode.value = mode
     }
@@ -277,7 +277,7 @@ class SeeAllViewModel @Inject constructor(@RoomVocaRepository private val vocaRe
                     onVocabularyUpdate(position)
                 }
                 MenuCode.DELETE -> {
-                    onDeleteModeChange(true)
+                    changeDeleteMode(true)
                     switchSelectedState(position)
                 }
                 MenuCode.SHOW_ON_NOTIFICATION -> {


### PR DESCRIPTION
## 뒤로 가기 버튼 관련 버그 수정 (Closes #50)
커스텀 key 리스너를 설정하여, 삭제 모드가 활성화됐을 때 뒤로 가기 버튼을 누르면 삭제 모드를 빠져나가도록 수정했다.
```
setOnKeyListener { _, keyCode, _ ->
    if (삭제 모드를 비활성해야 할 때) {
        // 이벤트 처리
        seeAllViewModel.changeDeleteMode(false)
        true
    } else {
        false
    }
}
```