### PR TITLE
[Refactor] VersusView

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" default="false" project-jdk-name="11" project-jdk-type="JavaSDK">
+  <component name="DesignSurface">
+    <option name="filePathToZoomLevelMap">
+      <map>
+        <entry key="..\:/code/MyVocabulary/app/src/main/res/layout/versus_view.xml" value="0.19882246376811594" />
+      </map>
+    </option>
+  </component>
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_8" project-jdk-name="11" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/hsk/practice/myvoca/MyVocaPreferences.kt
+++ b/app/src/main/java/hsk/practice/myvoca/MyVocaPreferences.kt
@@ -1,0 +1,49 @@
+package hsk.practice.myvoca
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.intPreferencesKey
+import androidx.datastore.preferences.preferencesDataStore
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.launch
+
+/**
+ * Preferences DataStore object. Delegated by preferenceDataStore().
+ * Once this property is initialized, it can be accessed through the whole application.
+ */
+val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
+
+fun <T> Context.getPreferencesFlow(key: Preferences.Key<T>): Flow<T> =
+    dataStore.data.map { preferences ->
+        preferences[key] ?: throw NoSuchElementException("Element $key doesn't exist")
+    }
+
+suspend fun <T> Context.getPreferences(key: Preferences.Key<T>): T {
+    return getPreferencesFlow(key).first()
+}
+
+suspend fun <T> Context.setPreferenceValue(key: Preferences.Key<T>, value: T) =
+    coroutineScope {
+        launch {
+            dataStore.edit { preferences ->
+                preferences[key] = value
+            }
+        }
+    }
+
+
+/**
+ * Stores preference keys only.
+ */
+object MyVocaPreferences {
+    private const val quizCorrectKeyString = "quiz_correct"
+    val quizCorrectKey = intPreferencesKey(quizCorrectKeyString)
+
+    private const val quizWrongKeyString = "quiz_wrong"
+    val quizWrongKey = intPreferencesKey(quizWrongKeyString)
+}

--- a/app/src/main/java/hsk/practice/myvoca/extensions.kt
+++ b/app/src/main/java/hsk/practice/myvoca/extensions.kt
@@ -1,17 +1,8 @@
 package hsk.practice.myvoca
 
-import android.content.Context
 import androidx.appcompat.app.AppCompatDelegate
-import androidx.datastore.core.DataStore
-import androidx.datastore.preferences.core.Preferences
-import androidx.datastore.preferences.preferencesDataStore
 import java.util.*
 
-/**
- * Preferences DataStore object. Delegated by preferenceDataStore().
- * Once this property is initialized, it can be accessed through the whole application.
- */
-val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
 
 /**
  * Checks if the given string contains only alphabet.
@@ -19,13 +10,8 @@ val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "se
  * @return `true` if string contains only alphabet, `false` otherwise
  */
 fun String?.containsOnlyAlphabet(): Boolean {
-    if (this.isNullOrEmpty()) return false
-    this.forEach {
-        if (it !in 'a'..'z' && it !in 'A'..'Z' && it != '%') {
-            return false
-        }
-    }
-    return true
+    if (isNullOrEmpty()) return false
+    return all { it in 'a'..'z' || it in 'A'..'Z' || it == '%' }
 }
 
 

--- a/app/src/main/java/hsk/practice/myvoca/framework/RoomVocabulary.kt
+++ b/app/src/main/java/hsk/practice/myvoca/framework/RoomVocabulary.kt
@@ -17,20 +17,25 @@ import java.io.Serializable
  * @memo: Memo for the word.
  */
 @Entity
-data class RoomVocabulary(@kotlin.jvm.JvmField @PrimaryKey var eng: String,
-                          @kotlin.jvm.JvmField var kor: String?,
-                          @kotlin.jvm.JvmField @ColumnInfo(name = "add_time") var addedTime: Long,
-                          @kotlin.jvm.JvmField @ColumnInfo(name = "last_update") var lastEditedTime: Long,
-                          @kotlin.jvm.JvmField var memo: String?)
-    : Serializable {
+data class RoomVocabulary(
+    @kotlin.jvm.JvmField @PrimaryKey var eng: String,
+    @kotlin.jvm.JvmField var kor: String?,
+    @kotlin.jvm.JvmField @ColumnInfo(name = "add_time") var addedTime: Long,
+    @kotlin.jvm.JvmField @ColumnInfo(name = "last_update") var lastEditedTime: Long,
+    @kotlin.jvm.JvmField var memo: String?
+) : Serializable {
+
+    val answerString: String
+        get() = "$eng: ${kor?.replace("\n", " ")}"
 
     companion object {
         val nullVocabulary = RoomVocabulary(
-                "null",
-                "널입니다.",
-                System.currentTimeMillis() / 1000,
-                System.currentTimeMillis() / 1000,
-                "")
+            "null",
+            "널입니다.",
+            System.currentTimeMillis() / 1000,
+            System.currentTimeMillis() / 1000,
+            ""
+        )
     }
 
     override fun equals(other: Any?) = eng == (other as? RoomVocabulary)?.eng ?: false

--- a/app/src/main/java/hsk/practice/myvoca/ui/customview/VersusView.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/customview/VersusView.kt
@@ -4,7 +4,17 @@ import android.content.Context
 import android.util.AttributeSet
 import android.view.LayoutInflater
 import android.widget.LinearLayout
+import hsk.practice.myvoca.MyVocaPreferences
 import hsk.practice.myvoca.databinding.VersusViewBinding
+import hsk.practice.myvoca.getPreferences
+import hsk.practice.myvoca.setPreferenceValue
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
 
 /**
  * Custom view which compares two values and show them with bar graph.
@@ -14,13 +24,64 @@ class VersusView @JvmOverloads constructor(
     context: Context,
     attrs: AttributeSet? = null,
     defStyleAttr: Int = 0
-) : LinearLayout(context, attrs, defStyleAttr) {
+) : LinearLayout(context, attrs, defStyleAttr), CoroutineScope {
+
+    private val job = Job()
+    override val coroutineContext: CoroutineContext
+        get() = job + Dispatchers.IO
+
+    private val _left = MutableStateFlow(0)
+    val left: StateFlow<Int>
+        get() = _left
+
+    private val _right = MutableStateFlow(0)
+    val right: StateFlow<Int>
+        get() = _right
 
     val binding = VersusViewBinding.inflate(LayoutInflater.from(context), this, true).apply {
-        viewModel = VersusViewModel()
+        data = VersusViewData(left, right)
     }
 
-    val viewModel: VersusViewModel
-        get() = binding.viewModel!!
+    init {
+        launch {
+            _left.value = context.getPreferences(MyVocaPreferences.quizCorrectKey)
+            _right.value = context.getPreferences(MyVocaPreferences.quizWrongKey)
+        }
+    }
+
+    override fun onDetachedFromWindow() {
+        super.onDetachedFromWindow()
+        saveValues()
+    }
+
+    fun setLeftValue(value: Int) {
+        if (value >= 0) {
+            _left.value = value
+        }
+    }
+
+    fun setRightValue(value: Int) {
+        if (value >= 0) {
+            _right.value = value
+        }
+    }
+
+    fun increaseLeftValue() {
+        setLeftValue(left.value + 1)
+    }
+
+    fun increaseRightValue() {
+        setRightValue(right.value + 1)
+    }
+
+    private fun saveValues() = launch {
+        context.setPreferenceValue(MyVocaPreferences.quizCorrectKey, left.value)
+        context.setPreferenceValue(MyVocaPreferences.quizWrongKey, right.value)
+    }
 
 }
+
+class VersusViewData(
+    val left: StateFlow<Int> = MutableStateFlow(0),
+    val right: StateFlow<Int> = MutableStateFlow(0)
+)

--- a/app/src/main/res/layout/versus_view.xml
+++ b/app/src/main/res/layout/versus_view.xml
@@ -2,10 +2,9 @@
 <layout xmlns:android="http://schemas.android.com/apk/res/android">
 
     <data>
-
         <variable
-            name="viewModel"
-            type="hsk.practice.myvoca.ui.customview.VersusViewModel" />
+            name="data"
+            type="hsk.practice.myvoca.ui.customview.VersusViewData"/>
     </data>
 
     <LinearLayout
@@ -24,7 +23,7 @@
                 style="@style/MediumTextViewStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@{viewModel.leftValue.toString()}" />
+                android:text="@{data.left.toString()}" />
 
             <View
                 android:layout_width="0dp"
@@ -36,7 +35,7 @@
                 style="@style/MediumTextViewStyle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@{viewModel.rightValue.toString()}" />
+                android:text="@{data.right.toString()}" />
 
         </LinearLayout>
 
@@ -50,7 +49,7 @@
                 android:id="@+id/left_bar"
                 android:layout_width="0dp"
                 android:layout_height="50dp"
-                android:layout_weight="@{viewModel.leftValue}"
+                android:layout_weight="@{data.left}"
                 android:background="@color/blue_600"
                 android:orientation="horizontal" />
 
@@ -58,7 +57,7 @@
                 android:id="@+id/right_bar"
                 android:layout_width="0dp"
                 android:layout_height="50dp"
-                android:layout_weight="@{viewModel.rightValue}"
+                android:layout_weight="@{data.right}"
                 android:background="@color/red_600"
                 android:orientation="horizontal" />
 


### PR DESCRIPTION
Closes #57
## ``VersusViewModel`` 제거
겨우 커스텀 뷰에서 ``ViewModel``을 사용하는 것은 적절하지 않다고 판단했다. 대신 뷰에서 사용하는 데이터를 ``VersusViewData``로 정의하여 data binding을 적용할 수 있도록 수정하였다. 이때 ``LiveData`` 대신 ``StateFlow``를 사용하였다.
## 퀴즈 결과 이벤트 추가
퀴즈 결과를 나타내는 ``QuizResult`` 클래스를 정의하였고, 퀴즈 결과를 나타내는 이벤트를 정의하여 뷰에서 처리할 수 있도록 하였다.
## Data store preferences 기능 수정
앱에서 사용하는 모든 preference의 키 값을 ``MyVocaPreferences``에 정의하였고, ``Context``의 suspend 확장 함수를 호출하여 data store preferences에 접근할 수 있도록 수정하였다.