### PR TITLE
[Refactor] VocaDao 리팩토링 (#67)

### DIFF
--- a/app/src/androidTest/java/hsk/practice/myvoca/room/VocaDaoTest.kt
+++ b/app/src/androidTest/java/hsk/practice/myvoca/room/VocaDaoTest.kt
@@ -7,8 +7,7 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import hsk.practice.myvoca.framework.RoomVocaDatabase
 import hsk.practice.myvoca.framework.RoomVocabulary
 import hsk.practice.myvoca.framework.VocaDao
-import kotlinx.coroutines.flow.collectIndexed
-import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.runBlocking
 import org.junit.After
 import org.junit.Assert.assertEquals
@@ -44,7 +43,7 @@ class VocaDaoTest {
         val currentTime = System.currentTimeMillis()
         val voca = RoomVocabulary(1, "test", "테스트", currentTime, currentTime, "dtd")
         vocaDao.insertVocabulary(voca)
-        val insertedVoca = vocaDao.loadVocabularyByEng("test")?.get(0)
+        val insertedVoca = vocaDao.loadVocabularyByEng("test")[0]
         assertEquals(voca, insertedVoca)
     }
 
@@ -52,9 +51,9 @@ class VocaDaoTest {
     @Throws(Exception::class)
     fun insertManyAndGet() = runBlocking {
         val currentTime = System.currentTimeMillis()
-        val vocaList = (1..10).mapIndexed { index, _ ->
+        val vocaList = (1..10).mapIndexed { _, value ->
             RoomVocabulary(
-                index,
+                value,
                 "dtd",
                 "테스트",
                 currentTime,
@@ -63,11 +62,9 @@ class VocaDaoTest {
             )
         }
         vocaDao.insertVocabulary(*vocaList.toTypedArray())
-        val allVocabulary = vocaDao.loadAllVocabulary().take(1)
-        allVocabulary.collectIndexed { _, value ->
-            for ((v1, v2) in vocaList.zip(value)) {
-                assertEquals(v1, v2)
-            }
+        val allVocabulary = vocaDao.loadAllVocabulary().first()
+        for ((v1, v2) in vocaList.zip(allVocabulary)) {
+            assertEquals(v1, v2)
         }
     }
 
@@ -76,8 +73,8 @@ class VocaDaoTest {
         val currentTime = System.currentTimeMillis()
         val test = RoomVocabulary(0, "test", "테스트", currentTime, currentTime, "")
         vocaDao.insertVocabulary(test)
-        vocaDao.loadVocabularyByEng("test")?.forEach {
-            it?.let { assertEquals(it.id, 1) }
+        vocaDao.loadVocabularyByEng("test").forEach {
+            assertEquals(it.id, 1)
         }
     }
 }

--- a/app/src/androidTest/java/hsk/practice/myvoca/room/VocaDaoTest.kt
+++ b/app/src/androidTest/java/hsk/practice/myvoca/room/VocaDaoTest.kt
@@ -22,6 +22,18 @@ class VocaDaoTest {
     private lateinit var vocaDao: VocaDao
     private lateinit var database: RoomVocaDatabase
 
+    private val vocaList = (1..10).mapIndexed { _, value ->
+        RoomVocabulary(
+            value,
+            "dtd",
+            "테스트",
+            System.currentTimeMillis(),
+            System.currentTimeMillis(),
+            "dtd"
+        )
+    }
+
+
     @Before
     fun createDatabase() {
         val context = ApplicationProvider.getApplicationContext<Context>()
@@ -40,27 +52,15 @@ class VocaDaoTest {
     @Test
     @Throws(Exception::class)
     fun insertAndGet() = runBlocking {
-        val currentTime = System.currentTimeMillis()
-        val voca = RoomVocabulary(1, "test", "테스트", currentTime, currentTime, "dtd")
+        val voca = vocaList[0]
         vocaDao.insertVocabulary(voca)
-        val insertedVoca = vocaDao.loadVocabularyByEng("test")[0]
+        val insertedVoca = vocaDao.loadVocabularyByEng("dtd")[0]
         assertEquals(voca, insertedVoca)
     }
 
     @Test
     @Throws(Exception::class)
     fun insertManyAndGet() = runBlocking {
-        val currentTime = System.currentTimeMillis()
-        val vocaList = (1..10).mapIndexed { _, value ->
-            RoomVocabulary(
-                value,
-                "dtd",
-                "테스트",
-                currentTime,
-                currentTime,
-                "dtd"
-            )
-        }
         vocaDao.insertVocabulary(*vocaList.toTypedArray())
         val allVocabulary = vocaDao.loadAllVocabulary().first()
         for ((v1, v2) in vocaList.zip(allVocabulary)) {
@@ -70,11 +70,20 @@ class VocaDaoTest {
 
     @Test
     fun checkIfKeyGenerated(): Unit = runBlocking {
-        val currentTime = System.currentTimeMillis()
-        val test = RoomVocabulary(0, "test", "테스트", currentTime, currentTime, "")
+        val test = vocaList[0].copy(
+            id = 0
+        )
         vocaDao.insertVocabulary(test)
         vocaDao.loadVocabularyByEng("test").forEach {
             assertEquals(it.id, 1)
         }
+    }
+
+    @Test
+    fun checkIdQuery() = runBlocking {
+        val voca = vocaList[0]
+        vocaDao.insertVocabulary(voca)
+        val testVoca = vocaDao.loadVocabularyById(1)
+        assertEquals(voca, testVoca)
     }
 }

--- a/app/src/main/java/hsk/practice/myvoca/framework/FakeVocaPersistence.kt
+++ b/app/src/main/java/hsk/practice/myvoca/framework/FakeVocaPersistence.kt
@@ -2,6 +2,7 @@ package hsk.practice.myvoca.framework
 
 import com.hsk.data.VocaPersistence
 import com.hsk.domain.vocabulary.Vocabulary
+import com.hsk.domain.vocabulary.nullVocabulary
 import hsk.practice.myvoca.containsOnlyAlphabet
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -21,11 +22,18 @@ class FakeVocaPersistence @Inject constructor() : VocaPersistence, CoroutineScop
         Vocabulary(2, "banana", "바나나", current, current, "")
     )
 
-    private val fakeDataFlow = MutableStateFlow<List<Vocabulary?>>(data)
+    private val fakeDataFlow = MutableStateFlow<List<Vocabulary>>(data)
 
-    override fun getAllVocabulary(): StateFlow<List<Vocabulary?>> = fakeDataFlow
+    override fun getAllVocabulary(): StateFlow<List<Vocabulary>> = fakeDataFlow
+    override suspend fun getVocabularyById(id: Int): Vocabulary {
+        return try {
+            data.first { it.id == id }
+        } catch (e: NoSuchElementException) {
+            nullVocabulary
+        }
+    }
 
-    override suspend fun getVocabulary(query: String): List<Vocabulary?> {
+    override suspend fun getVocabulary(query: String): List<Vocabulary> {
         return if (query.containsOnlyAlphabet()) {
             data.filter { it.eng.contains(query) }
         } else {
@@ -33,18 +41,18 @@ class FakeVocaPersistence @Inject constructor() : VocaPersistence, CoroutineScop
         }
     }
 
-    override suspend fun insertVocabulary(vararg vocabularies: Vocabulary?) {
+    override suspend fun insertVocabulary(vararg vocabularies: Vocabulary) {
         for (voca in vocabularies) {
-            voca?.let { data.add(it) }
+            voca.let { data.add(it) }
         }
         data.sortBy { it.eng }
     }
 
-    override suspend fun updateVocabulary(vararg vocabularies: Vocabulary?) {
+    override suspend fun updateVocabulary(vararg vocabularies: Vocabulary) {
         // Not necessary, so didn't implemented.
     }
 
-    override suspend fun deleteVocabulary(vararg vocabularies: Vocabulary?) {
+    override suspend fun deleteVocabulary(vararg vocabularies: Vocabulary) {
         for (voca in vocabularies) {
             data.remove(voca)
         }

--- a/app/src/main/java/hsk/practice/myvoca/framework/VocaDao.kt
+++ b/app/src/main/java/hsk/practice/myvoca/framework/VocaDao.kt
@@ -41,6 +41,14 @@ interface VocaDao {
     fun loadAllVocabulary(): Flow<List<RoomVocabulary>>
 
     /**
+     * Loads vocabulary by id.
+     *
+     * @param id id to search
+     */
+    @Query("SELECT * FROM RoomVocabulary WHERE id LIKE :id")
+    suspend fun loadVocabularyById(id: Int): RoomVocabulary?
+
+    /**
      * Loads vocabularies that matches with the english word
      *
      * @param eng english word to search

--- a/app/src/main/java/hsk/practice/myvoca/framework/VocaDao.kt
+++ b/app/src/main/java/hsk/practice/myvoca/framework/VocaDao.kt
@@ -15,7 +15,7 @@ interface VocaDao {
      * @param vocabularies objects to insert to the database
      */
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    suspend fun insertVocabulary(vararg vocabularies: RoomVocabulary?)
+    suspend fun insertVocabulary(vararg vocabularies: RoomVocabulary)
 
     /**
      * Updates given vocabularies.
@@ -23,7 +23,7 @@ interface VocaDao {
      * @param vocabularies objects to update from the database
      */
     @Update
-    suspend fun updateVocabulary(vararg vocabularies: RoomVocabulary?)
+    suspend fun updateVocabulary(vararg vocabularies: RoomVocabulary)
 
     /**
      * Deletes given vocabularies from the database.
@@ -31,7 +31,7 @@ interface VocaDao {
      * @param vocabularies objects to delete from the database
      */
     @Delete
-    suspend fun deleteVocabulary(vararg vocabularies: RoomVocabulary?)
+    suspend fun deleteVocabulary(vararg vocabularies: RoomVocabulary)
 
     /**
      * Loads all vocabulary and sort the result by ascending alphabetic order.
@@ -47,7 +47,7 @@ interface VocaDao {
      * @return vocabularies whose word is similar to eng
      */
     @Query("SELECT * from RoomVocabulary WHERE eng LIKE :eng")
-    suspend fun loadVocabularyByEng(eng: String?): List<RoomVocabulary?>?
+    suspend fun loadVocabularyByEng(eng: String?): List<RoomVocabulary>
 
     /**
      * Loads vocabularies that matches with the korean meaning
@@ -55,5 +55,5 @@ interface VocaDao {
      * @return vocabularies whose meaning is similar to kor
      */
     @Query("SELECT * from RoomVocabulary WHERE kor LIKE :kor")
-    suspend fun loadVocabularyByKor(kor: String?): List<RoomVocabulary?>?
+    suspend fun loadVocabularyByKor(kor: String?): List<RoomVocabulary>
 }

--- a/app/src/main/java/hsk/practice/myvoca/framework/VocaPersistenceDatabase.kt
+++ b/app/src/main/java/hsk/practice/myvoca/framework/VocaPersistenceDatabase.kt
@@ -41,7 +41,7 @@ class VocaPersistenceDatabase @Inject constructor(@ApplicationContext context: C
 
     private var vocaDao: VocaDao
 
-    private val _allVocabulary = MutableStateFlow<List<Vocabulary?>>(emptyList())
+    private val _allVocabulary = MutableStateFlow<List<Vocabulary>>(emptyList())
 
     init {
         synchronized(this) {
@@ -54,8 +54,12 @@ class VocaPersistenceDatabase @Inject constructor(@ApplicationContext context: C
         loadAllVocabulary()
     }
 
-    override fun getAllVocabulary(): StateFlow<List<Vocabulary?>> {
+    override fun getAllVocabulary(): StateFlow<List<Vocabulary>> {
         return _allVocabulary
+    }
+
+    override suspend fun getVocabularyById(id: Int): Vocabulary? {
+        return vocaDao.loadVocabularyById(id)?.toVocabulary()
     }
 
     private fun loadAllVocabulary() = launch {
@@ -65,23 +69,23 @@ class VocaPersistenceDatabase @Inject constructor(@ApplicationContext context: C
         }
     }
 
-    override suspend fun getVocabulary(query: String): List<Vocabulary?>? {
+    override suspend fun getVocabulary(query: String): List<Vocabulary> {
         return if (query.containsOnlyAlphabet()) {
             vocaDao.loadVocabularyByEng("%${query}%")
         } else {
             vocaDao.loadVocabularyByKor(query)
-        }?.toVocabularyList()
+        }.toVocabularyList()
     }
 
-    override suspend fun deleteVocabulary(vararg vocabularies: Vocabulary?) {
+    override suspend fun deleteVocabulary(vararg vocabularies: Vocabulary) {
         vocaDao.deleteVocabulary(*vocabularies.toRoomVocabularyArray())
     }
 
-    override suspend fun updateVocabulary(vararg vocabularies: Vocabulary?) {
+    override suspend fun updateVocabulary(vararg vocabularies: Vocabulary) {
         vocaDao.updateVocabulary(*vocabularies.toRoomVocabularyArray())
     }
 
-    override suspend fun insertVocabulary(vararg vocabularies: Vocabulary?) {
+    override suspend fun insertVocabulary(vararg vocabularies: Vocabulary) {
         vocaDao.insertVocabulary(*vocabularies.toRoomVocabularyArray())
     }
 }

--- a/app/src/main/java/hsk/practice/myvoca/framework/extensions.kt
+++ b/app/src/main/java/hsk/practice/myvoca/framework/extensions.kt
@@ -12,28 +12,28 @@ fun Vocabulary.toVocabularyImpl() = VocabularyImpl(
     id, eng, kor, addedTime, lastEditedTime, memo
 )
 
-fun List<Vocabulary?>?.toRoomVocabularyList() = this?.map { it?.toRoomVocabulary() }
+fun List<Vocabulary>.toRoomVocabularyList() = this.map { it.toRoomVocabulary() }
 
-fun List<Vocabulary?>?.toRoomVocabularyMutableList() = this?.toRoomVocabularyList()?.toMutableList()
+fun List<Vocabulary>.toRoomVocabularyMutableList() = this.toRoomVocabularyList().toMutableList()
 
-fun List<Vocabulary?>?.toVocabularyImplList() = this?.map { it?.toVocabularyImpl() }
+fun List<Vocabulary>.toVocabularyImplList() = this.map { it.toVocabularyImpl() }
 
-fun Array<out Vocabulary?>.toRoomVocabularyArray() =
-    this.map { it?.toRoomVocabulary() }.toTypedArray()
+fun Array<out Vocabulary>.toRoomVocabularyArray() =
+    this.map { it.toRoomVocabulary() }.toTypedArray()
 
 
 /* Convert RoomVocabulary to other types */
-fun RoomVocabulary?.toVocabulary() =
-    this?.let { Vocabulary(it.id, it.eng, it.kor, it.addedTime, it.lastEditedTime, it.memo) }
+fun RoomVocabulary.toVocabulary() =
+    this.let { Vocabulary(it.id, it.eng, it.kor, it.addedTime, it.lastEditedTime, it.memo) }
 
-fun RoomVocabulary?.toVocabularyImpl() =
-    this?.let { VocabularyImpl(it.id, it.eng, it.kor, it.addedTime, it.lastEditedTime, it.memo) }
+fun RoomVocabulary.toVocabularyImpl() =
+    this.let { VocabularyImpl(it.id, it.eng, it.kor, it.addedTime, it.lastEditedTime, it.memo) }
 
-fun List<RoomVocabulary?>.toVocabularyList() = this.map { it.toVocabulary() }
+fun List<RoomVocabulary>.toVocabularyList() = this.map { it.toVocabulary() }
 
-fun List<RoomVocabulary?>.vocabularyImplList() = this.map { it.toVocabularyImpl() }
+fun List<RoomVocabulary>.vocabularyImplList() = this.map { it.toVocabularyImpl() }
 
-fun Array<out RoomVocabulary?>.toVocabularyArray() = this.map { it?.toVocabulary() }.toTypedArray()
+fun Array<out RoomVocabulary>.toVocabularyArray() = this.map { it.toVocabulary() }.toTypedArray()
 
 
 /* Convert VocabularyImpl to other types */

--- a/app/src/main/java/hsk/practice/myvoca/framework/extensions.kt
+++ b/app/src/main/java/hsk/practice/myvoca/framework/extensions.kt
@@ -38,7 +38,7 @@ fun Array<out RoomVocabulary>.toVocabularyArray() = this.map { it.toVocabulary()
 
 /* Convert VocabularyImpl to other types */
 fun VocabularyImpl.toRoomVocabulary(): RoomVocabulary = RoomVocabulary(
-    id = id ?: 0,
+    id = id,
     eng = eng,
     kor = kor,
     addedTime = addedTime,
@@ -47,7 +47,7 @@ fun VocabularyImpl.toRoomVocabulary(): RoomVocabulary = RoomVocabulary(
 )
 
 fun VocabularyImpl.toVocabulary(): Vocabulary = Vocabulary(
-    id = id ?: 0,
+    id = id,
     eng = eng,
     kor = kor,
     addedTime = addedTime,

--- a/app/src/main/java/hsk/practice/myvoca/ui/seeall/SeeAllViewModel.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/seeall/SeeAllViewModel.kt
@@ -39,12 +39,12 @@ enum class SortMethod(val value: Int) {
 class SeeAllViewModel @Inject constructor(@RoomVocaRepository private val vocaRepository: VocaRepository) :
     ViewModel() {
 
-    private val _allVocabulary = MutableLiveData<List<VocabularyImpl?>?>()
-    val allVocabulary: LiveData<List<VocabularyImpl?>?>
+    private val _allVocabulary = MutableLiveData<List<VocabularyImpl>>()
+    val allVocabulary: LiveData<List<VocabularyImpl>>
         get() = _allVocabulary
 
-    private val _currentVocabulary = MutableLiveData<MutableList<VocabularyImpl?>?>()
-    val currentVocabulary: LiveData<MutableList<VocabularyImpl?>?>
+    private val _currentVocabulary = MutableLiveData<MutableList<VocabularyImpl>>()
+    val currentVocabulary: LiveData<MutableList<VocabularyImpl>>
         get() = _currentVocabulary
 
     private val _deleteMode = MutableLiveData(false)
@@ -67,7 +67,7 @@ class SeeAllViewModel @Inject constructor(@RoomVocaRepository private val vocaRe
             _allVocabulary.postValue(it.toVocabularyImplList())
             if (!searchMode) {
                 val sortedList = sortItems(it, sortState.value!!)
-                _currentVocabulary.postValue(sortedList.toVocabularyImplList()?.toMutableList())
+                _currentVocabulary.postValue(sortedList.toVocabularyImplList().toMutableList())
             }
         }
     }
@@ -93,10 +93,10 @@ class SeeAllViewModel @Inject constructor(@RoomVocaRepository private val vocaRe
      * @param query String to search with. [query] should not include % character.
      */
     fun searchVocabulary(query: String) = viewModelScope.launch(Dispatchers.IO) {
-        val result = vocaRepository.getVocabulary(query) ?: return@launch
+        val result = vocaRepository.getVocabulary(query)
         val sortedResult = sortItems(result, sortState.value!!)
         val sortedMutableList = sortedResult.map {
-            it?.toVocabularyImpl()
+            it.toVocabularyImpl()
         }.toMutableList()
         _currentVocabulary.postValue(sortedMutableList)
 //        sortItems(sortState) // TODO: what is this?
@@ -129,8 +129,8 @@ class SeeAllViewModel @Inject constructor(@RoomVocaRepository private val vocaRe
     fun sortItems() = viewModelScope.launch {
         _currentVocabulary.value?.apply {
             when (sortState.value) {
-                SortMethod.ENG -> this.sortBy { it?.eng }
-                SortMethod.EDITED_TIME -> this.sortByDescending { it?.addedTime }
+                SortMethod.ENG -> this.sortBy { it.eng }
+                SortMethod.EDITED_TIME -> this.sortByDescending { it.addedTime }
                 else -> {
                     Logger.d("정렬할 수 없습니다: method ${sortState.value}")
                 }
@@ -138,10 +138,10 @@ class SeeAllViewModel @Inject constructor(@RoomVocaRepository private val vocaRe
         }
     }
 
-    fun sortItems(items: List<Vocabulary?>, method: SortMethod): List<Vocabulary?> {
+    fun sortItems(items: List<Vocabulary>, method: SortMethod): List<Vocabulary> {
         return when (method) {
-            SortMethod.ENG -> items.sortedBy { it?.eng }
-            SortMethod.EDITED_TIME -> items.sortedByDescending { it?.addedTime }
+            SortMethod.ENG -> items.sortedBy { it.eng }
+            SortMethod.EDITED_TIME -> items.sortedByDescending { it.addedTime }
         }
     }
 

--- a/data/src/main/java/com/hsk/data/VocaPersistence.kt
+++ b/data/src/main/java/com/hsk/data/VocaPersistence.kt
@@ -12,28 +12,28 @@ interface VocaPersistence {
     /**
      * Loads all vocabularies from the database and return them as LiveData.
      */
-    fun getAllVocabulary(): StateFlow<List<Vocabulary?>>
+    fun getAllVocabulary(): StateFlow<List<Vocabulary>>
 
     /**
      * Loads a vocabulary which matches with the given query.
      * Query can be English or Korean.
      * Loads a vocabulary whose eng(former) or kor(latter) contains the query.
      */
-    suspend fun getVocabulary(query: String): List<Vocabulary?>?
+    suspend fun getVocabulary(query: String): List<Vocabulary>
 
     /**
      * Inserts vocabularies to the database.
      */
-    suspend fun insertVocabulary(vararg vocabularies: Vocabulary?)
+    suspend fun insertVocabulary(vararg vocabularies: Vocabulary)
 
     /**
      * Updates the given vocabulary.
      */
-    suspend fun updateVocabulary(vararg vocabularies: Vocabulary?)
+    suspend fun updateVocabulary(vararg vocabularies: Vocabulary)
 
     /**
      * Deletes the given vocabulary. This operation is permanent.
      */
-    suspend fun deleteVocabulary(vararg vocabularies: Vocabulary?)
+    suspend fun deleteVocabulary(vararg vocabularies: Vocabulary)
 
 }

--- a/data/src/main/java/com/hsk/data/VocaPersistence.kt
+++ b/data/src/main/java/com/hsk/data/VocaPersistence.kt
@@ -15,6 +15,11 @@ interface VocaPersistence {
     fun getAllVocabulary(): StateFlow<List<Vocabulary>>
 
     /**
+     * Loads a vocabulary whose id is equal to the parameter [id].
+     */
+    suspend fun getVocabularyById(id: Int): Vocabulary?
+
+    /**
      * Loads a vocabulary which matches with the given query.
      * Query can be English or Korean.
      * Loads a vocabulary whose eng(former) or kor(latter) contains the query.

--- a/data/src/main/java/com/hsk/data/VocaRepository.kt
+++ b/data/src/main/java/com/hsk/data/VocaRepository.kt
@@ -20,6 +20,10 @@ class VocaRepository(private val vocaPersistence: VocaPersistence) : CoroutineSc
         return vocaPersistence.getAllVocabulary()
     }
 
+    suspend fun getVocabularyById(id: Int): Vocabulary? {
+        return vocaPersistence.getVocabularyById(id)
+    }
+
     suspend fun getVocabulary(query: String): List<Vocabulary> {
         return vocaPersistence.getVocabulary(query)
     }

--- a/data/src/main/java/com/hsk/data/VocaRepository.kt
+++ b/data/src/main/java/com/hsk/data/VocaRepository.kt
@@ -1,12 +1,12 @@
 package com.hsk.data
 
 import com.hsk.domain.vocabulary.Vocabulary
+import com.hsk.domain.vocabulary.nullVocabulary
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.first
 import kotlin.coroutines.CoroutineContext
 
 class VocaRepository(private val vocaPersistence: VocaPersistence) : CoroutineScope {
@@ -16,35 +16,31 @@ class VocaRepository(private val vocaPersistence: VocaPersistence) : CoroutineSc
     override val coroutineContext: CoroutineContext
         get() = job + Dispatchers.Default
 
-    fun getAllVocabulary(): StateFlow<List<Vocabulary?>> {
+    fun getAllVocabulary(): StateFlow<List<Vocabulary>> {
         return vocaPersistence.getAllVocabulary()
     }
 
-    suspend fun getVocabulary(query: String): List<Vocabulary?>? {
+    suspend fun getVocabulary(query: String): List<Vocabulary> {
         return vocaPersistence.getVocabulary(query)
     }
 
-    suspend fun getRandomVocabulary(): Vocabulary? {
-        var resultVoca: Vocabulary? = null
-        getAllVocabulary().take(1).collect {
-            resultVoca = try {
-                it.shuffled().first()
-            } catch (e: NoSuchElementException) {
-                Vocabulary(-1, "null", "널", 0, 0, "")
-            }
+    suspend fun getRandomVocabulary(): Vocabulary {
+        return try {
+            getAllVocabulary().first().shuffled().first()
+        } catch (e: NoSuchElementException) {
+            nullVocabulary
         }
-        return resultVoca
     }
 
-    suspend fun insertVocabulary(vararg vocabularies: Vocabulary?) {
+    suspend fun insertVocabulary(vararg vocabularies: Vocabulary) {
         vocaPersistence.insertVocabulary(*vocabularies)
     }
 
-    suspend fun updateVocabulary(vararg vocabularies: Vocabulary?) {
+    suspend fun updateVocabulary(vararg vocabularies: Vocabulary) {
         vocaPersistence.updateVocabulary(*vocabularies)
     }
 
-    suspend fun deleteVocabulary(vararg vocabularies: Vocabulary?) {
+    suspend fun deleteVocabulary(vararg vocabularies: Vocabulary) {
         vocaPersistence.deleteVocabulary(*vocabularies)
     }
 

--- a/domain/src/main/java/com/hsk/domain/vocabulary/Vocabulary.kt
+++ b/domain/src/main/java/com/hsk/domain/vocabulary/Vocabulary.kt
@@ -10,3 +10,13 @@ data class Vocabulary(
     val lastEditedTime: Long,
     val memo: String?
 ) : Serializable
+
+val nullVocabulary: Vocabulary
+    get() = Vocabulary(
+        id = 0,
+        eng = "null",
+        kor = "널",
+        addedTime = System.currentTimeMillis(),
+        lastEditedTime = System.currentTimeMillis(),
+        memo = ""
+    )


### PR DESCRIPTION
# VocaDao 리팩토링 (Closes #67)
## ``id``를 검색하는 query 추가
먼저 domain 레이어의 ``VocaPersistence``와 ``VocaRepository``에 함수 정의를 추가한다. 검색 결과가 없을 경우를 대비하여 리턴 타입을 ``Vocabulary?``로 선언한다.

그 후, 앱의 ``framework`` 패키지에서 함수를 구현한다. 구현한 함수를 테스트하는 코드 역시 작성했다. (``VocaDaoTest.checkIdQuery()`` 참고)

## Query에서 불필요한 nullable(``?``) 제거
꼭 필요한 경우를 제외하고는 nullable을 리턴하지 않는다. 

*Nullable이 꼭 필요한 경우*: ``Flow<T>``가 아닌 ``T``를 반환하는 query에서 ``T``가 ``List`` 등의 collection이 아닌 경우. 즉 검색 결과를 하나의 POJO로 리턴하는 경우