### PR TITLE
Firestore 백업/복원 기능 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -126,8 +126,8 @@ dependencies {
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
 
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1-native-mt'
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1-native-mt'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-core:1.5.1'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.5.1'
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-play-services:1.5.0'
 
     implementation "androidx.room:room-runtime:$room_version"
@@ -163,10 +163,7 @@ dependencies {
     implementation platform('com.google.firebase:firebase-bom:28.4.0')
     implementation 'com.google.firebase:firebase-auth-ktx'
     implementation 'com.google.firebase:firebase-firestore-ktx'
-    // Firebase SDK for Google Analytics
     implementation 'com.google.firebase:firebase-analytics-ktx'
-    // Firebase UI for Login
-    implementation 'com.firebaseui:firebase-ui-auth:8.0.0'
 
     implementation 'com.orhanobut:logger:2.2.0'
 

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,7 +2,6 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'dagger.hilt.android.plugin'
-apply plugin: 'androidx.navigation.safeargs'
 apply plugin: 'com.google.gms.google-services'
 
 android {
@@ -61,7 +60,6 @@ android {
     }
     composeOptions {
         kotlinCompilerExtensionVersion compose_version
-        kotlinCompilerVersion kotlin_version
     }
 }
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -36,13 +36,7 @@
         <provider
             android:name="androidx.startup.InitializationProvider"
             android:authorities="${applicationId}.androidx-startup"
-            android:exported="false"
-            tools:node="merge">
-            <meta-data
-                android:name="androidx.work.impl.WorkManagerInitializer"
-                android:value="androidx.startup"
-                tools:node="remove" />
-        </provider>
+            tools:node="remove" />
     </application>
 
 </manifest>

--- a/app/src/main/java/hsk/practice/myvoca/data/VocabularyImpl.kt
+++ b/app/src/main/java/hsk/practice/myvoca/data/VocabularyImpl.kt
@@ -6,11 +6,11 @@ import java.io.Serializable
 
 data class VocabularyImpl(
     val id: Int = 0,
-    val eng: String,
-    val meaning: List<MeaningImpl>,
-    val addedTime: Long,
-    val lastEditedTime: Long,
-    val memo: String?
+    val eng: String = "",
+    val meaning: List<MeaningImpl> = emptyList(),
+    val addedTime: Long = 0L,
+    val lastEditedTime: Long = 0L,
+    val memo: String? = ""
 ) : Serializable {
 
     companion object {
@@ -47,8 +47,8 @@ val VocabularyImpl.answerString: String
     get() = "$eng: ${meaning.joinToString("; ") { it.content }}"
 
 data class MeaningImpl(
-    val type: WordClassImpl,
-    val content: String
+    val type: WordClassImpl = WordClassImpl.UNKNOWN,
+    val content: String = ""
 ) : Serializable
 
 enum class WordClassImpl(val korean: String) {

--- a/app/src/main/java/hsk/practice/myvoca/firebase/MyFirestore.kt
+++ b/app/src/main/java/hsk/practice/myvoca/firebase/MyFirestore.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.tasks.await
 
 object MyFirestore {
 
-    // TODO: 백업/복원 기능 추가하기
     private const val backupDocument = "backup"
     private const val backupData = "data"
 

--- a/app/src/main/java/hsk/practice/myvoca/firebase/MyFirestore.kt
+++ b/app/src/main/java/hsk/practice/myvoca/firebase/MyFirestore.kt
@@ -1,0 +1,23 @@
+package hsk.practice.myvoca.firebase
+
+import com.google.firebase.firestore.ktx.firestore
+import com.google.firebase.ktx.Firebase
+
+/**
+ * 데이터 저장 구조: ${uid}(컬렉션) - backup(문서) - data(컬렉션)
+ * data 안에 각 단어가 개별 문서로 저장된다.
+ *
+ * Q. 왜 uid로 먼저 묶었는가?
+ * A. 유저별 데이터를 묶고 싶었기 때문.
+ */
+
+object MyFirestore {
+
+    // TODO: 백업/복원 기능 추가하기
+    private const val backupDocument = "backup"
+    private const val backupData = "data"
+
+    fun backupDataReference(userId: String) =
+        Firebase.firestore.collection("$userId/$backupDocument/$backupData")
+
+}

--- a/app/src/main/java/hsk/practice/myvoca/firebase/MyFirestore.kt
+++ b/app/src/main/java/hsk/practice/myvoca/firebase/MyFirestore.kt
@@ -1,7 +1,9 @@
 package hsk.practice.myvoca.firebase
 
+import com.google.firebase.firestore.CollectionReference
 import com.google.firebase.firestore.ktx.firestore
 import com.google.firebase.ktx.Firebase
+import kotlinx.coroutines.tasks.await
 
 /**
  * 데이터 저장 구조: ${uid}(컬렉션) - backup(문서) - data(컬렉션)
@@ -19,5 +21,14 @@ object MyFirestore {
 
     fun backupDataReference(userId: String) =
         Firebase.firestore.collection("$userId/$backupDocument/$backupData")
+
+    suspend fun collectionExists(collection: CollectionReference): Boolean {
+        val result = collection.get().await()
+        return !result.isEmpty
+    }
+
+    suspend fun collectionExists(path: String): Boolean {
+        return collectionExists(Firebase.firestore.collection(path))
+    }
 
 }

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/profile/ProfileScreen.kt
@@ -2,25 +2,32 @@ package hsk.practice.myvoca.ui.screens.profile
 
 import android.content.Context
 import android.content.Intent
+import android.net.Uri
+import android.widget.Toast
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.content.res.AppCompatResources
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.Image
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.material.LocalContentColor
-import androidx.compose.material.MaterialTheme
-import androidx.compose.material.Text
-import androidx.compose.material.TextButton
+import androidx.compose.foundation.lazy.GridCells
+import androidx.compose.foundation.lazy.LazyVerticalGrid
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.*
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.FileDownload
+import androidx.compose.material.icons.outlined.FileUpload
+import androidx.compose.material.icons.outlined.HelpOutline
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.graphics.vector.rememberVectorPainter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -28,8 +35,6 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import coil.annotation.ExperimentalCoilApi
 import coil.compose.rememberImagePainter
 import coil.transform.CircleCropTransformation
-import com.google.accompanist.drawablepainter.rememberDrawablePainter
-import hsk.practice.myvoca.R
 import hsk.practice.myvoca.firebase.UserImpl
 import hsk.practice.myvoca.ui.theme.MyVocaTheme
 
@@ -38,39 +43,31 @@ fun ProfileScreen(viewModel: ProfileViewModel = hiltViewModel()) {
     val data by viewModel.profileScreenData.collectAsState()
 
     ProfileContent(
-        user = data.user,
+        data = data,
         onTryLogin = viewModel::onTryLogin,
         onLoginButtonClick = viewModel::onLoginButtonClick,
-        onLogout = viewModel::onLogout
+        onLogout = viewModel::onLogout,
+        profileFeatures = viewModel.profileFeatures,
+        onUploadConfirm = viewModel::onUploadConfirm,
+        onUploadDismiss = viewModel::onUploadDismiss,
+        onDownloadConfirm = viewModel::onDownloadConfirm,
+        onDownloadDismiss = viewModel::onDownloadDismiss
     )
 }
 
-@OptIn(ExperimentalCoilApi::class)
 @Composable
 private fun ProfileContent(
-    user: UserImpl?,
+    data: ProfileScreenData,
     onTryLogin: (ActivityResult) -> Unit,
     onLoginButtonClick: (Context, ManagedActivityResultLauncher<Intent, ActivityResult>) -> Unit,
-    onLogout: () -> Unit
+    onLogout: () -> Unit,
+    profileFeatures: List<ProfileFeature>,
+    onUploadConfirm: () -> Unit,
+    onUploadDismiss: () -> Unit,
+    onDownloadConfirm: (() -> Unit) -> Unit,
+    onDownloadDismiss: () -> Unit,
 ) {
-    val profileImageSize = 150
-    val profileImage = if (user?.profileImageUrl == null) {
-        rememberDrawablePainter(
-            drawable = AppCompatResources.getDrawable(
-                LocalContext.current,
-                R.drawable.ic_outline_person_24
-            )
-        )
-    } else {
-        rememberImagePainter(
-            data = user.profileImageUrl,
-            builder = {
-                size(profileImageSize)
-                transformations(CircleCropTransformation())
-            }
-        )
-    }
-
+    val user = data.user
     Column(
         modifier = Modifier
             .fillMaxWidth()
@@ -78,41 +75,68 @@ private fun ProfileContent(
     ) {
         ProfileImage(
             modifier = Modifier
-                .size(profileImageSize.dp)
                 .padding(start = 20.dp),
-            painter = profileImage
+            imageUrl = user?.profileImageUrl
         )
 
-        if (user != null) {
-            ProfileUserDetail(
-                username = user.username ?: "알 수 없는 이름입니다.",
-                email = user.email ?: "알 수 없는 이메일입니다.",
-                onLogout = onLogout
-            )
-        } else {
-            ProfileLogin(
-                onTryLogin = onTryLogin,
-                onLoginButtonClick = onLoginButtonClick
-            )
+        Box(
+            modifier = Modifier.height(48.dp),
+            contentAlignment = Alignment.CenterStart
+        ) {
+            if (user != null) {
+                ProfileUserDetail(
+                    username = user.username ?: "알 수 없는 이름입니다.",
+                    email = user.email ?: "알 수 없는 이메일입니다.",
+                    onLogout = onLogout
+                )
+            } else {
+                ProfileLogin(
+                    onTryLogin = onTryLogin,
+                    onLoginButtonClick = onLoginButtonClick
+                )
+            }
         }
+        Spacer(modifier = Modifier.padding(vertical = 10.dp))
 
-        ProfileNotFullyImplemented(
+        ProfileFeatures(
             modifier = Modifier
                 .fillMaxWidth()
-                .weight(2f)
+                .weight(2f),
+            user = user,
+            features = profileFeatures,
         )
         Spacer(modifier = Modifier.weight(3f))
     }
+
+    if (data.showUploadDialog) {
+        ProfileUploadDialog(onConfirm = onUploadConfirm, onDismiss = onUploadDismiss)
+    }
+    if (data.showDownloadDialog) {
+        ProfileDownloadDialog(onConfirm = onDownloadConfirm, onDismiss = onDownloadDismiss)
+    }
 }
 
+@OptIn(ExperimentalCoilApi::class)
 @Composable
 private fun ProfileImage(
     modifier: Modifier = Modifier,
-    painter: Painter
+    imageUrl: Uri?
 ) {
+    val imageSize = 150
+    val imagePainter = if (imageUrl == null) {
+        rememberVectorPainter(image = Icons.Outlined.HelpOutline)
+    } else {
+        rememberImagePainter(
+            data = imageUrl,
+            builder = {
+                size(imageSize)
+                transformations(CircleCropTransformation())
+            }
+        )
+    }
     Image(
-        modifier = modifier,
-        painter = painter,
+        modifier = modifier.size(imageSize.dp),
+        painter = imagePainter,
         contentDescription = "프로필 이미지",
     )
 }
@@ -161,29 +185,136 @@ private fun ProfileLogin(
     }
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
-private fun ProfileNotFullyImplemented(modifier: Modifier = Modifier) {
-    Column(
-        modifier = modifier,
-        horizontalAlignment = Alignment.CenterHorizontally,
-        verticalArrangement = Arrangement.Center
-    ) {
-        CompositionLocalProvider(LocalContentColor provides Color.Gray) {
-            Text(text = "아직 아무것도 없습니다.")
-            Text(text = "추후 기능이 업데이트될 예정입니다.")
+private fun ProfileFeatures(
+    modifier: Modifier = Modifier,
+    user: UserImpl?,
+    features: List<ProfileFeature>
+) {
+    val clickable = user != null
+    LazyVerticalGrid(cells = GridCells.Fixed(3), modifier = modifier) {
+        items(features) { feature ->
+            ProfileFeatureItem(
+                feature = feature,
+                enabled = clickable
+            )
         }
     }
+
+}
+
+@Composable
+private fun ProfileFeatureItem(
+    feature: ProfileFeature,
+    enabled: Boolean
+) {
+    val alpha by animateFloatAsState(targetValue = if (enabled) 1f else 0.5f)
+    Column(
+        horizontalAlignment = Alignment.CenterHorizontally,
+        modifier = Modifier
+            .clickable(enabled = enabled, onClick = feature.onClick)
+            .aspectRatio(1f)
+            .alpha(alpha),
+        verticalArrangement = Arrangement.SpaceEvenly
+    ) {
+        Icon(
+            imageVector = feature.icon,
+            contentDescription = feature.text,
+            modifier = Modifier.fillMaxSize(0.4f)
+        )
+        Text(text = feature.text)
+    }
+}
+
+@Composable
+private fun ProfileUploadDialog(
+    onConfirm: () -> Unit,
+    onDismiss: () -> Unit
+) {
+    AlertDialog(
+        title = { Text(text = "단어 백업하기") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(text = "단어를 백업하시겠습니까?")
+                Text(text = "단어는 클라우드에 백업되며, 언제든지 앱으로 가져올 수 있습니다.")
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onConfirm) {
+                Text(text = "확인")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = "취소")
+            }
+        },
+        onDismissRequest = onDismiss
+    )
+}
+
+@Composable
+private fun ProfileDownloadDialog(
+    onConfirm: (() -> Unit) -> Unit,
+    onDismiss: () -> Unit
+) {
+    val context = LocalContext.current
+    AlertDialog(
+        title = { Text(text = "단어 복원하기") },
+        text = {
+            Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
+                Text(text = "단어를 복원하시겠습니까?")
+                Text(text = "클라우드의 데이터를 기기로 복원합니다.")
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = {
+                onConfirm {
+                    // When there is no data to restore
+                    Toast.makeText(context, "가져올 데이터가 없습니다.", Toast.LENGTH_LONG).show()
+                }
+            }) {
+                Text(text = "확인")
+            }
+        },
+        dismissButton = {
+            TextButton(onClick = onDismiss) {
+                Text(text = "취소")
+            }
+        },
+        onDismissRequest = onDismiss
+    )
 }
 
 @Preview(showBackground = true)
 @Composable
 private fun ProfileContentPreview() {
+    val data = ProfileScreenData(
+        user = UserImpl(uid = "dtd", username = "hsk", email = null, profileImageUrl = null)
+    )
     MyVocaTheme {
         ProfileContent(
-            user = UserImpl(uid = "dtd", username = "hsk", email = null, profileImageUrl = null),
+            data = data,
             onTryLogin = {},
             onLoginButtonClick = { _, _ -> },
-            onLogout = {}
+            onLogout = {},
+            profileFeatures = listOf(
+                ProfileFeature(
+                    icon = Icons.Outlined.FileUpload,
+                    text = "단어 백업하기",
+                    onClick = { }
+                ),
+                ProfileFeature(
+                    icon = Icons.Outlined.FileDownload,
+                    text = "단어 복원하기",
+                    onClick = { }
+                )
+            ),
+            onUploadConfirm = {},
+            onUploadDismiss = {},
+            onDownloadConfirm = {},
+            onDownloadDismiss = {}
         )
     }
 }

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/profile/ProfileViewModel.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/profile/ProfileViewModel.kt
@@ -4,25 +4,70 @@ import android.content.Context
 import android.content.Intent
 import androidx.activity.compose.ManagedActivityResultLauncher
 import androidx.activity.result.ActivityResult
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.FileDownload
+import androidx.compose.material.icons.outlined.FileUpload
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import androidx.work.WorkManager
 import com.google.firebase.auth.FirebaseUser
+import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import hsk.practice.myvoca.firebase.MyFirebaseAuth
+import hsk.practice.myvoca.firebase.MyFirestore
 import hsk.practice.myvoca.firebase.UserImpl
+import hsk.practice.myvoca.work.setFirestoreDownloadWork
+import hsk.practice.myvoca.work.setFirestoreUploadWork
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
-class ProfileViewModel : ViewModel() {
+@HiltViewModel
+class ProfileViewModel @Inject constructor(@ApplicationContext context: Context) : ViewModel() {
+
+    private val workManager = WorkManager.getInstance(context)
 
     private val _profileScreenData = MutableStateFlow(ProfileScreenData())
     val profileScreenData: StateFlow<ProfileScreenData>
         get() = _profileScreenData
 
+    val profileFeatures = listOf(
+        ProfileFeature(
+            icon = Icons.Outlined.FileUpload,
+            text = "단어 백업하기",
+            onClick = {
+                _profileScreenData.value = profileScreenData.value.copy(showUploadDialog = true)
+            }
+        ),
+        ProfileFeature(
+            icon = Icons.Outlined.FileDownload,
+            text = "단어 복원하기",
+            onClick = {
+                _profileScreenData.value = profileScreenData.value.copy(showDownloadDialog = true)
+            }
+        )
+    )
+
     init {
         MyFirebaseAuth.addAuthStateListener { auth ->
-            onLoginStateChange(auth.currentUser)
+            val user = auth.currentUser
+            onLoginStateChange(user)
+
+            // Check if backup data exists at the Firestore
+            if (user != null) {
+                viewModelScope.launch {
+                    val backupDataPath = MyFirestore.backupDataReference(user.uid)
+                    val exists = MyFirestore.collectionExists(backupDataPath)
+                    _profileScreenData.value =
+                        profileScreenData.value.copy(downloadPossible = exists)
+                }
+            }
         }
     }
 
+    /* Event listeners for Compose UI */
     fun onLoginButtonClick(
         context: Context,
         launcher: ManagedActivityResultLauncher<Intent, ActivityResult>
@@ -46,10 +91,58 @@ class ProfileViewModel : ViewModel() {
 
     fun onLogout() = MyFirebaseAuth.logout()
 
+    fun onUploadConfirm() {
+        scheduleUploadWork()
+        hideUploadDialog()
+    }
+
+    fun onUploadDismiss() {
+        hideUploadDialog()
+    }
+
+    private fun hideUploadDialog() {
+        _profileScreenData.value = profileScreenData.value.copy(showUploadDialog = false)
+    }
+
+    fun onDownloadConfirm(onFailure: () -> Unit) {
+        if (profileScreenData.value.downloadPossible == true) {
+            scheduleDownloadWork()
+        } else {
+            onFailure()
+        }
+        hideDownloadDialog()
+    }
+
+    fun onDownloadDismiss() {
+        hideDownloadDialog()
+    }
+
+    private fun hideDownloadDialog() {
+        _profileScreenData.value = profileScreenData.value.copy(showDownloadDialog = false)
+    }
+
+    private fun scheduleUploadWork() {
+        val user = profileScreenData.value.user ?: return
+        setFirestoreUploadWork(workManager, user.uid!!)
+    }
+
+    private fun scheduleDownloadWork() {
+        val user = profileScreenData.value.user ?: return
+        setFirestoreDownloadWork(workManager, user.uid!!)
+    }
+
 }
 
 
 data class ProfileScreenData(
-    val user: UserImpl? = null
+    val user: UserImpl? = null,
+    val showUploadDialog: Boolean = false,
+    val showDownloadDialog: Boolean = false,
+    val downloadPossible: Boolean? = null
 )
 
+data class ProfileFeature(
+    val icon: ImageVector,
+    val text: String,
+    val onClick: () -> Unit
+)

--- a/app/src/main/java/hsk/practice/myvoca/work/FirestoreDownloadWordsWork.kt
+++ b/app/src/main/java/hsk/practice/myvoca/work/FirestoreDownloadWordsWork.kt
@@ -1,0 +1,63 @@
+package hsk.practice.myvoca.work
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.*
+import com.orhanobut.logger.Logger
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import hsk.practice.myvoca.data.VocabularyImpl
+import hsk.practice.myvoca.firebase.MyFirestore
+import hsk.practice.myvoca.room.RoomVocaDatabase
+import hsk.practice.myvoca.room.vocabulary.VocaDao
+import hsk.practice.myvoca.room.vocabulary.toRoomVocabulary
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.tasks.await
+import kotlinx.coroutines.withContext
+
+@HiltWorker
+class FirestoreDownloadWordsWork @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val database: RoomVocaDatabase
+) : CoroutineWorker(context, workerParams) {
+
+    companion object {
+        const val userIdKey = "user"
+    }
+
+    private val vocaDao: VocaDao
+        get() = database.vocaDao()!!
+
+    override suspend fun doWork(): Result {
+        val userId = inputData.getString(userIdKey) ?: return Result.failure()
+
+        val dataRef = MyFirestore.backupDataReference(userId)
+        val result = dataRef.get().addOnFailureListener { error ->
+            Logger.e("Firestore download error: $error")
+        }.await()
+
+        val words = result.toObjects(VocabularyImpl::class.java)
+        withContext(Dispatchers.IO) {
+            val databaseList = words.map { it.toRoomVocabulary() }
+            vocaDao.insertVocabulary(databaseList)
+        }
+
+        return Result.success()
+    }
+
+}
+
+private const val downloadWorkTag = "FirestoreDownloadWork"
+
+fun setFirestoreDownloadWork(
+    workManager: WorkManager,
+    userId: String
+) {
+    val data = workDataOf(FirestoreDownloadWordsWork.userIdKey to userId)
+    val work = OneTimeWorkRequestBuilder<FirestoreDownloadWordsWork>()
+        .addTag(downloadWorkTag)
+        .setInputData(data)
+        .build()
+    workManager.enqueueUniqueWork(downloadWorkTag, ExistingWorkPolicy.KEEP, work)
+}

--- a/app/src/main/java/hsk/practice/myvoca/work/FirestoreUploadWordsWork.kt
+++ b/app/src/main/java/hsk/practice/myvoca/work/FirestoreUploadWordsWork.kt
@@ -1,0 +1,71 @@
+package hsk.practice.myvoca.work
+
+import android.content.Context
+import androidx.hilt.work.HiltWorker
+import androidx.work.*
+import com.orhanobut.logger.Logger
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import hsk.practice.myvoca.firebase.MyFirestore
+import hsk.practice.myvoca.room.RoomVocaDatabase
+import hsk.practice.myvoca.room.vocabulary.VocaDao
+import hsk.practice.myvoca.room.vocabulary.vocabularyImplList
+import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.take
+
+@HiltWorker
+class FirestoreUploadWordsWork @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val database: RoomVocaDatabase
+) : CoroutineWorker(context, workerParams) {
+
+    private val backupDocument = "backup"
+    private val backupData = "data"
+
+    companion object {
+        const val userIdKey = "user"
+        const val progressKey = "progress"
+    }
+
+    private val vocaDao: VocaDao
+        get() = database.vocaDao()!!
+
+    override suspend fun doWork(): Result {
+        val uid = inputData.getString(userIdKey) ?: return Result.failure()
+        vocaDao.loadAllVocabulary().take(2).map { list -> list.vocabularyImplList() }
+            .collectLatest { words ->
+                val backupRef = MyFirestore.backupDataReference(uid)
+                var progress = 0f
+                val progressPerWord = 100f / words.size
+
+                words.forEach { word ->
+                    backupRef.document(word.id.toString()).set(word)
+                        .addOnSuccessListener {
+                            Logger.d("Firestore Success!")
+                            progress += progressPerWord
+                            setProgressAsync(workDataOf(progressKey to progress))
+                        }.addOnFailureListener {
+                            Logger.e("Firestore error!")
+                        }
+                }
+            }
+        return Result.success()
+    }
+
+}
+
+private const val uploadWorkTag = "FirestoreUploadWork"
+
+fun setFirestoreUploadWork(
+    workManager: WorkManager,
+    userId: String
+) {
+    val data = workDataOf(FirestoreUploadWordsWork.userIdKey to userId)
+    val work = OneTimeWorkRequestBuilder<FirestoreUploadWordsWork>()
+        .addTag(uploadWorkTag)
+        .setInputData(data)
+        .build()
+    workManager.enqueueUniqueWork(uploadWorkTag, ExistingWorkPolicy.KEEP, work)
+}

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,6 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:7.1.0-alpha05'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath "androidx.navigation:navigation-safe-args-gradle-plugin:2.3.5"
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
         // Firebase integration
         classpath 'com.google.gms:google-services:4.3.10'


### PR DESCRIPTION
## Firestore 연동 추가!
이제 Firestore에 단어를 백업하고 복원할 수 있다. 
## 저장 구조
* 사용자의 모든 데이터를 저장할 최상위 컬렉션을 만든다. 컬렉션의 이름은 ``uid``이다.
* 사용자의 컬렉션 안에는 다양한 데이터가 문서로 저장된다. 지금은 ``backup``만 저장된다.
* ``backup`` 문서 안에는 다시 ``data`` 컬렉션이 존재하고, ``data`` 컬렉션 안에 단어가 개별 문서로 저장된다.