### PR TITLE
2.0 rc2

### DIFF
--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/profile/ProfileViewModel.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/profile/ProfileViewModel.kt
@@ -18,6 +18,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import hsk.practice.myvoca.firebase.MyFirebaseAuth
 import hsk.practice.myvoca.firebase.MyFirestore
 import hsk.practice.myvoca.firebase.UserImpl
+import hsk.practice.myvoca.util.equalsDelta
 import hsk.practice.myvoca.work.FirestoreUploadWordsWork
 import hsk.practice.myvoca.work.setFirestoreDownloadWork
 import hsk.practice.myvoca.work.setFirestoreUploadWork
@@ -222,7 +223,7 @@ data class UploadFeatureData(
     val uploading: Boolean
         get() = uploadProgress != null
     val finished: Boolean
-        get() = if (uploadProgress == null) false else uploadProgress >= 1f
+        get() = uploadProgress?.equalsDelta(1f) ?: false
 }
 
 data class DownloadFeatureData(

--- a/app/src/main/java/hsk/practice/myvoca/util/extensions.kt
+++ b/app/src/main/java/hsk/practice/myvoca/util/extensions.kt
@@ -9,6 +9,7 @@ import java.time.LocalTime
 import java.time.ZoneId
 import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
+import kotlin.math.abs
 
 
 /**
@@ -136,3 +137,11 @@ fun getSecondsLeft(): Long {
     Logger.d("time: $time")
     return 60 * 60 * 24L - time.toSecondOfDay()
 }
+
+
+/**
+ * Floating point equal comparison.
+ * Uses [IBM formula](https://www.ibm.com/developerworks/java/library/j-jtp0114/#N10255), which is more robust
+ * because taking a ratio of 2 numbers **cancels** out the effect of their scale relative to delta.
+ */
+fun Float.equalsDelta(other: Float) = abs(this / other - 1) < 1e-5


### PR DESCRIPTION
## 버그 수정: 부동소수점 간의 == 연산 구현
두 값의 차이가 일정 값(델타)보다 작을 때 두 값이 같다고 판정하는 함수를 추가하였다. 이를 통해 백업 진행도를 계산할 때 부동소수점의 한계로 인해 값을 정확히 비교할 수 없는 문제를 해결하였다.