### PR TITLE
단어 리스트에 애니메이션 넣기

### DIFF
--- a/app/src/main/java/hsk/practice/myvoca/ui/components/WordContent.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/components/WordContent.kt
@@ -31,10 +31,12 @@ import hsk.practice.myvoca.util.toTimeString
 @Composable
 fun WordContent(
     word: VocabularyImpl,
+    modifier: Modifier = Modifier,
     iconContent: @Composable RowScope.() -> Unit = {}
 ) {
     var expanded by remember { mutableStateOf(false) }
     WordContent(
+        modifier = modifier,
         word = word,
         expanded = expanded,
         onExpanded = { expanded = !it },
@@ -45,6 +47,7 @@ fun WordContent(
 @Composable
 fun WordContent(
     word: VocabularyImpl,
+    modifier: Modifier = Modifier,
     showExpandButton: Boolean = true,
     expanded: Boolean,
     onExpanded: (Boolean) -> Unit,
@@ -52,7 +55,7 @@ fun WordContent(
 ) {
     val padding = 8.dp
     Column(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .background(color = MaterialTheme.colors.surface)
             .padding(padding),

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/allword/AllWord.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/allword/AllWord.kt
@@ -4,10 +4,16 @@ import android.content.Context
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.animateColorAsState
+import androidx.compose.animation.core.CubicBezierEasing
+import androidx.compose.animation.core.tween
+import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.*
-import androidx.compose.foundation.lazy.*
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.foundation.text.KeyboardOptions
@@ -418,7 +424,7 @@ fun SortStateChip(
     }
 }
 
-@OptIn(ExperimentalAnimationApi::class)
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun AllWordItems(
     words: List<VocabularyImpl>,
@@ -433,10 +439,19 @@ fun AllWordItems(
             state = listState,
             verticalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            items(items = words,
+            items(
+                items = words,
                 key = { it.id }
             ) { word ->
-                WordContent(word) {
+                WordContent(
+                    modifier = Modifier.animateItemPlacement(
+                        tween(
+                            durationMillis = 1500,
+                            easing = CubicBezierEasing(0.7f, 0.1f, 0.3f, 0.9f)
+                        )
+                    ),
+                    word = word
+                ) {
                     IconButton(onClick = { onWordUpdate(word, context) }) {
                         Icon(
                             imageVector = Icons.Outlined.Edit,


### PR DESCRIPTION
# Closes #108 
단어 리스트의 내용이 바뀔 때 단어들이 움직이는 애니메이션을 넣었다. Compose 1.1.0에서 새로 추가된 ``Modifier.animateItemPlacement()`` API를 사용하였다

https://user-images.githubusercontent.com/45386920/153395553-7b80fe93-8ba5-497a-98eb-842040c5c582.mp4

