### PR TITLE
Immutable list 적용

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -266,6 +266,9 @@ dependencies {
     // Gson
     implementation 'com.google.code.gson:gson:2.9.0'
 
+    // kotlin immutable collections
+    implementation "org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5"
+
     implementation project(':data')
     implementation project(':domain')
 }

--- a/app/src/main/java/hsk/practice/myvoca/data/VocabularyImpl.kt
+++ b/app/src/main/java/hsk/practice/myvoca/data/VocabularyImpl.kt
@@ -3,11 +3,14 @@ package hsk.practice.myvoca.data
 import com.hsk.data.Meaning
 import com.hsk.data.WordClass
 import com.hsk.ktx.removed
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 
 data class VocabularyImpl(
     val id: Int = 0,
     val eng: String = "",
-    val meaning: List<MeaningImpl> = emptyList(),
+    val meaning: ImmutableList<MeaningImpl> = persistentListOf(),
     val addedTime: Long = 0L,
     val lastEditedTime: Long = 0L,
     val memo: String? = ""
@@ -19,7 +22,7 @@ data class VocabularyImpl(
         val nullVocabulary = VocabularyImpl(
             id = 0,
             eng = "null",
-            meaning = emptyList(),
+            meaning = persistentListOf(),
             addedTime = System.currentTimeMillis(),
             lastEditedTime = System.currentTimeMillis(),
             memo = ""
@@ -37,7 +40,7 @@ val fakeData: List<VocabularyImpl> = (1..20).map { index ->
                 if (it % 2 == 0) WordClassImpl.NOUN else WordClassImpl.VERB,
                 "테스트$index"
             )
-        },
+        }.toImmutableList(),
         addedTime = currentTime,
         lastEditedTime = currentTime,
         memo = ""

--- a/app/src/main/java/hsk/practice/myvoca/room/vocabulary/extensions.kt
+++ b/app/src/main/java/hsk/practice/myvoca/room/vocabulary/extensions.kt
@@ -9,6 +9,7 @@ import hsk.practice.myvoca.data.MeaningImpl
 import hsk.practice.myvoca.data.VocabularyImpl
 import hsk.practice.myvoca.data.toMeaning
 import hsk.practice.myvoca.data.toMeaningImpl
+import kotlinx.collections.immutable.toImmutableList
 import java.lang.reflect.Type
 
 internal inline fun <reified T> getTypeTokenType(): Type = object : TypeToken<T>() {}.type
@@ -31,7 +32,7 @@ fun Vocabulary.toRoomVocabulary(): RoomVocabulary {
 }
 
 fun Vocabulary.toVocabularyImpl() = VocabularyImpl(
-    id, eng, meaning.map { it.toMeaningImpl() }, addedTime, lastEditedTime, memo
+    id, eng, meaning.map { it.toMeaningImpl() }.toImmutableList(), addedTime, lastEditedTime, memo
 )
 
 @JvmName("toRoomVocabularyListVocabulary")
@@ -52,8 +53,8 @@ fun RoomVocabulary.toVocabulary(): Vocabulary {
 }
 
 fun RoomVocabulary.toVocabularyImpl(): VocabularyImpl {
-    val meaningList =
-        kor?.let { Gson().fromJson<List<MeaningImpl>>(it) } ?: return VocabularyImpl.nullVocabulary
+    val meaningList = kor?.let { Gson().fromJson<List<MeaningImpl>>(it) }?.toImmutableList()
+        ?: return VocabularyImpl.nullVocabulary
     return VocabularyImpl(id, eng, meaningList, addedTime, lastEditedTime, memo)
 }
 

--- a/app/src/main/java/hsk/practice/myvoca/ui/components/BottomAppBar.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/components/BottomAppBar.kt
@@ -24,6 +24,8 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import hsk.practice.myvoca.ui.structure.MyVocaScreen
 import hsk.practice.myvoca.ui.theme.MyVocaTheme
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.toImmutableList
 import java.util.*
 
 private val TabHeight = 56.dp
@@ -35,7 +37,7 @@ private const val TabFadeOutDuration = 100
 
 @Composable
 fun MyVocaBottomAppBar(
-    allScreens: List<MyVocaScreen>,
+    allScreens: ImmutableList<MyVocaScreen>,
     onTabSelected: (MyVocaScreen) -> Unit,
     currentScreen: MyVocaScreen
 ) {
@@ -114,7 +116,7 @@ private fun MyVocaTab(
 fun MyVocaBottomAppBarPreview() {
     MyVocaTheme {
         MyVocaBottomAppBar(
-            allScreens = MyVocaScreen.values().toList(),
+            allScreens = MyVocaScreen.values().toList().toImmutableList(),
             onTabSelected = { },
             currentScreen = MyVocaScreen.Home
         )

--- a/app/src/main/java/hsk/practice/myvoca/ui/components/WordContent.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/components/WordContent.kt
@@ -1,6 +1,5 @@
 package hsk.practice.myvoca.ui.components
 
-import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
@@ -27,6 +26,7 @@ import hsk.practice.myvoca.data.MeaningImpl
 import hsk.practice.myvoca.data.VocabularyImpl
 import hsk.practice.myvoca.data.WordClassImpl
 import hsk.practice.myvoca.ui.theme.MyVocaTheme
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 
 @Composable
@@ -94,7 +94,7 @@ fun WordTitle(
 
 @Composable
 fun WordMeanings(
-    meanings: List<MeaningImpl>,
+    meanings: ImmutableList<MeaningImpl>,
     modifier: Modifier = Modifier,
     showExpandButton: Boolean = true,
     expanded: Boolean = false,
@@ -178,7 +178,6 @@ fun WordMeaning(
     }
 }
 
-@OptIn(ExperimentalAnimationApi::class)
 @Preview
 @Composable
 fun WordContentPreview() {

--- a/app/src/main/java/hsk/practice/myvoca/ui/components/WordContent.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/components/WordContent.kt
@@ -27,6 +27,7 @@ import hsk.practice.myvoca.data.MeaningImpl
 import hsk.practice.myvoca.data.VocabularyImpl
 import hsk.practice.myvoca.data.WordClassImpl
 import hsk.practice.myvoca.ui.theme.MyVocaTheme
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun WordContent(
@@ -189,7 +190,7 @@ fun WordContentPreview() {
             MeaningImpl(WordClassImpl.NOUN, "(지식 등을 알아보기 위한) 시험"),
             MeaningImpl(WordClassImpl.NOUN, "(의료적인) 검사"),
             MeaningImpl(WordClassImpl.VERB, "시험하다"),
-        ),
+        ).toImmutableList(),
         addedTime = currentTime,
         lastEditedTime = currentTime,
         memo = ""

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordScreen.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordScreen.kt
@@ -30,6 +30,7 @@ import hsk.practice.myvoca.ui.components.InsetAwareTopAppBar
 import hsk.practice.myvoca.ui.components.StaggeredGrid
 import hsk.practice.myvoca.ui.components.SystemBarColor
 import hsk.practice.myvoca.ui.theme.MyVocaTheme
+import kotlinx.collections.immutable.ImmutableList
 
 @Composable
 fun AddWordScreen(
@@ -240,7 +241,7 @@ private fun Word(
 
 @Composable
 private fun Meanings(
-    meanings: List<MeaningImpl>,
+    meanings: ImmutableList<MeaningImpl>,
     onMeaningAdd: (WordClassImpl) -> Unit,
     onMeaningUpdate: (Int, MeaningImpl) -> Unit,
     onMeaningDelete: (Int) -> Unit
@@ -353,7 +354,7 @@ private fun MeaningsEmptyIndicator() {
 
 @Composable
 private fun MeaningsContent(
-    meanings: List<MeaningImpl>,
+    meanings: ImmutableList<MeaningImpl>,
     onMeaningUpdate: (Int, MeaningImpl) -> Unit,
     onMeaningDelete: (Int) -> Unit
 ) {

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordViewModel.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordViewModel.kt
@@ -12,6 +12,9 @@ import hsk.practice.myvoca.data.WordClassImpl
 import hsk.practice.myvoca.module.LocalVocaPersistence
 import hsk.practice.myvoca.room.vocabulary.toVocabularyImpl
 import hsk.practice.myvoca.room.vocabulary.toVocabularyList
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -99,9 +102,9 @@ class AddWordViewModel @Inject constructor(
         updateUiState(meanings = newMeanings)
     }
 
-    private fun applyToMeanings(block: MutableList<MeaningImpl>.() -> Unit): List<MeaningImpl> {
+    private fun applyToMeanings(block: MutableList<MeaningImpl>.() -> Unit): ImmutableList<MeaningImpl> {
         val meanings = uiStateFlow.value.meanings.toMutableList()
-        return meanings.apply { block() }
+        return meanings.apply { block() }.toImmutableList()
     }
 
     fun onMemoUpdate(memo: String) {
@@ -134,7 +137,7 @@ class AddWordViewModel @Inject constructor(
         screenType: ScreenType = uiStateFlow.value.screenType,
         word: String = uiStateFlow.value.word,
         wordExistStatus: WordExistStatus = uiStateFlow.value.wordExistStatus,
-        meanings: List<MeaningImpl> = uiStateFlow.value.meanings,
+        meanings: ImmutableList<MeaningImpl> = uiStateFlow.value.meanings,
         memo: String = uiStateFlow.value.memo
     ) {
         _uiStateFlow.value = AddWordScreenData(
@@ -164,14 +167,14 @@ data class AddWordScreenData(
     val screenType: ScreenType = AddWord,
     val word: String = "",
     val wordExistStatus: WordExistStatus = WordExistStatus.WORD_EMPTY,
-    val meanings: List<MeaningImpl> = emptyList(),
+    val meanings: ImmutableList<MeaningImpl> = persistentListOf(),
     val memo: String = "",
 ) {
     fun toVocabularyImpl(): VocabularyImpl {
         val current = System.currentTimeMillis()
         return VocabularyImpl(
             eng = word,
-            meaning = meanings,
+            meaning = meanings.toImmutableList(),
             addedTime = current,
             lastEditedTime = current,
             memo = memo

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/allword/AllWord.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/allword/AllWord.kt
@@ -41,6 +41,8 @@ import hsk.practice.myvoca.ui.components.LoadingIndicator
 import hsk.practice.myvoca.ui.components.WordContent
 import hsk.practice.myvoca.ui.state.UiState
 import hsk.practice.myvoca.ui.theme.MyVocaTheme
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentSetOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
@@ -376,7 +378,7 @@ private fun QueryWord(
 
 @Composable
 private fun QueryWordClass(
-    selectedWordClass: Set<WordClass>,
+    selectedWordClass: ImmutableSet<WordClass>,
     onOptionWordClassClick: (String) -> Unit
 ) {
     LazyRow(modifier = Modifier.padding(8.dp)) {
@@ -484,7 +486,7 @@ private fun SortStateChip(
 @OptIn(ExperimentalFoundationApi::class)
 @Composable
 private fun WordItems(
-    words: List<VocabularyImpl>,
+    words: ImmutableList<VocabularyImpl>,
     onWordUpdate: (VocabularyImpl, Context) -> Unit,
     onWordDelete: (VocabularyImpl) -> Unit
 ) {
@@ -601,7 +603,7 @@ private fun ContentsPreview() {
 private fun WordItemsPreview() {
     MyVocaTheme {
         WordItems(
-            words = fakeData,
+            words = fakeData.toImmutableList(),
             onWordUpdate = { _, _ -> },
             onWordDelete = {}
         )

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/allword/AllWord.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/allword/AllWord.kt
@@ -41,6 +41,8 @@ import hsk.practice.myvoca.ui.components.LoadingIndicator
 import hsk.practice.myvoca.ui.components.WordContent
 import hsk.practice.myvoca.ui.state.UiState
 import hsk.practice.myvoca.ui.theme.MyVocaTheme
+import kotlinx.collections.immutable.persistentSetOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
@@ -395,7 +397,6 @@ private fun QueryWordClass(
     }
 }
 
-@OptIn(ExperimentalAnimationApi::class)
 @Composable
 private fun WordClassChip(
     className: String,
@@ -572,7 +573,7 @@ private fun ContentsPreview() {
     MyVocaTheme {
         Content(
             data = AllWordData(
-                currentWordState = fakeData,
+                currentWordState = fakeData.toImmutableList(),
                 queryState = VocabularyQuery(word = word)
             ),
             onOptionButtonClicked = { },
@@ -611,7 +612,7 @@ private fun WordItemsPreview() {
 @Composable
 private fun QueryOptionsPreview() {
     var word = "test text"
-    val wordClassSet = mutableSetOf<WordClass>()
+    val wordClassSet = persistentSetOf<WordClass>()
 
     MyVocaTheme {
         QueryOptions(
@@ -644,7 +645,7 @@ private fun QueryOptionsPreview() {
 @Composable
 private fun QueryOptionsPreview_DarkMode() {
     var word = "test text"
-    val wordClassSet = mutableSetOf<WordClass>()
+    val wordClassSet = persistentSetOf<WordClass>()
 
     MyVocaTheme {
         QueryOptions(

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/allword/AllWordViewModel.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/allword/AllWordViewModel.kt
@@ -2,7 +2,6 @@ package hsk.practice.myvoca.ui.screens.allword
 
 import android.content.Context
 import android.content.Intent
-import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hsk.data.VocabularyQuery
@@ -19,6 +18,10 @@ import hsk.practice.myvoca.room.vocabulary.toVocabularyImplList
 import hsk.practice.myvoca.room.vocabulary.toVocabularyList
 import hsk.practice.myvoca.ui.screens.addword.AddWordActivity
 import hsk.practice.myvoca.ui.state.UiState
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
+import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -62,7 +65,7 @@ class AllWordViewModel @Inject constructor(
             val result = loadWords(data.queryState).sortedBy(data.sortState)
             _allWordUiState.value = allWordUiState.value.copy(
                 loading = false,
-                data = data.copy(currentWordState = result)
+                data = data.copy(currentWordState = result.toImmutableList())
             )
         }
     }
@@ -95,8 +98,8 @@ class AllWordViewModel @Inject constructor(
                 emptySet()
             } else {
                 val wordClass = WordClassImpl.findByKorean(koreanName)?.toWordClass() ?: return
-                current.xor(wordClass).toSet()
-            }
+                current.xor(wordClass)
+            }.toImmutableSet()
             onQueryChanged(queryState.copy(wordClass = new))
         }
     }
@@ -158,18 +161,17 @@ private fun MutableStateFlow<UiState<AllWordData>>.copyData(
         val newData = data.copy(
             sortState = sortState ?: data.sortState,
             queryState = queryState ?: data.queryState,
-            currentWordState = currentWordState ?: data.currentWordState,
+            currentWordState = currentWordState?.toImmutableList() ?: data.currentWordState,
             deletedWord = deletedWord ?: data.deletedWord
         )
         this.value = this.value.copy(data = newData)
     }
 }
 
-@Immutable
 data class AllWordData(
     val sortState: SortState = SortState.defaultValue,
     val queryState: VocabularyQuery = VocabularyQuery(),
-    val currentWordState: List<VocabularyImpl> = emptyList(),
+    val currentWordState: ImmutableList<VocabularyImpl> = persistentListOf(),
     val deletedWord: VocabularyImpl? = null
 )
 

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/home/HomeScreen.kt
@@ -27,6 +27,7 @@ import hsk.practice.myvoca.ui.components.WordContent
 import hsk.practice.myvoca.ui.theme.MyVocaTheme
 import hsk.practice.myvoca.util.getTimeDiffString
 import hsk.practice.myvoca.work.setPeriodicTodayWordWork
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 import java.time.LocalDateTime
 import java.time.ZoneOffset
@@ -105,7 +106,7 @@ private fun Content(
 
 @Composable
 private fun TodayWords(
-    todayWords: List<HomeTodayWord>,
+    todayWords: ImmutableList<HomeTodayWord>,
     lastUpdatedTime: Long,
     enableRefresh: Boolean,
     showTodayWordHelp: (Boolean) -> Unit,
@@ -126,7 +127,7 @@ private fun TodayWords(
 
 @Composable
 private fun TodayWordItems(
-    todayWords: List<HomeTodayWord>,
+    todayWords: ImmutableList<HomeTodayWord>,
     onTodayWordCheckboxChange: (HomeTodayWord) -> Unit
 ) {
     LazyColumn(

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/home/HomeScreen.kt
@@ -27,6 +27,7 @@ import hsk.practice.myvoca.ui.components.WordContent
 import hsk.practice.myvoca.ui.theme.MyVocaTheme
 import hsk.practice.myvoca.util.getTimeDiffString
 import hsk.practice.myvoca.work.setPeriodicTodayWordWork
+import kotlinx.collections.immutable.toImmutableList
 import java.time.LocalDateTime
 import java.time.ZoneOffset
 
@@ -302,7 +303,7 @@ private fun ContentPreview() {
         totalWordCount = fakeData.size,
         todayWords = fakeData.subList(0, 5).map { voca ->
             HomeTodayWord(TodayWordImpl(wordId = voca.id), voca)
-        },
+        }.toImmutableList(),
         todayWordsLastUpdatedTime = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC)
     )
     MyVocaTheme {

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/home/HomeViewModel.kt
@@ -1,6 +1,5 @@
 package hsk.practice.myvoca.ui.screens.home
 
-import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import androidx.work.WorkManager
@@ -21,6 +20,9 @@ import hsk.practice.myvoca.room.vocabulary.toVocabularyImpl
 import hsk.practice.myvoca.util.MyVocaPreferencesKey
 import hsk.practice.myvoca.util.PreferencesDataStore
 import hsk.practice.myvoca.work.setOneTimeTodayWordWork
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -65,6 +67,7 @@ class HomeViewModel @Inject constructor(
 
                 val todayWordList =
                     createHomeTodayWords(todayWords, actualTodayWords).sortTodayWords()
+                        .toImmutableList()
                 data.copy(
                     loading = false,
                     totalWordCount = size,
@@ -116,7 +119,7 @@ class HomeViewModel @Inject constructor(
 private fun MutableStateFlow<HomeScreenData>.copyData(
     loading: Boolean = value.loading,
     totalWordCount: Int = value.totalWordCount,
-    todayWords: List<HomeTodayWord> = value.todayWords,
+    todayWords: ImmutableList<HomeTodayWord> = value.todayWords,
     todayWordsLastUpdatedTime: Long = value.todayWordsLastUpdatedTime,
     showTodayWordHelp: Boolean = value.showTodayWordHelp
 ) {
@@ -131,17 +134,15 @@ private fun MutableStateFlow<HomeScreenData>.copyData(
     }
 }
 
-@Immutable
 data class HomeTodayWord(
     val todayWord: TodayWordImpl,
     val vocabulary: VocabularyImpl
 )
 
-@Immutable
 data class HomeScreenData(
     val loading: Boolean = false,
     val totalWordCount: Int = 0,
-    val todayWords: List<HomeTodayWord> = emptyList(),
+    val todayWords: ImmutableList<HomeTodayWord> = persistentListOf(),
     val todayWordsLastUpdatedTime: Long = LocalDateTime.now().toEpochSecond(ZoneOffset.UTC),
     val showTodayWordHelp: Boolean = false
 )

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/quiz/QuizScreen.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/quiz/QuizScreen.kt
@@ -25,6 +25,7 @@ import hsk.practice.myvoca.ui.components.versus.VersusView
 import hsk.practice.myvoca.ui.components.versus.rememberVersusViewState
 import hsk.practice.myvoca.ui.screens.addword.AddWordActivity
 import hsk.practice.myvoca.ui.theme.MyVocaTheme
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun QuizScreen(viewModel: QuizViewModel) {
@@ -118,7 +119,7 @@ private fun QuizContent(
         Spacer(modifier = Modifier.weight(1f))
         QuizOptions(
             modifier = Modifier.weight(8f),
-            options = quiz.quizList,
+            options = quiz.quizWords,
             onOptionClick = onOptionClick
         )
         VersusView(
@@ -230,7 +231,10 @@ private fun QuizNotAvailablePreview() {
 @Preview(showBackground = true)
 @Composable
 private fun QuizScreenPreview() {
-    val quiz = Quiz(fakeData.distinctRandoms(quizSize), answerIndex = (0 until quizSize).random())
+    val quiz = Quiz(
+        quizWords = fakeData.distinctRandoms(quizSize).toImmutableList(),
+        answerIndex = (0 until quizSize).random()
+    )
     val quizStat = QuizStat(10, 5)
 
     var text by remember { mutableStateOf("dtd") }

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/quiz/QuizScreen.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/quiz/QuizScreen.kt
@@ -25,6 +25,7 @@ import hsk.practice.myvoca.ui.components.versus.VersusView
 import hsk.practice.myvoca.ui.components.versus.rememberVersusViewState
 import hsk.practice.myvoca.ui.screens.addword.AddWordActivity
 import hsk.practice.myvoca.ui.theme.MyVocaTheme
+import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 
 @Composable
@@ -154,7 +155,7 @@ private fun QuizTitle(answer: VocabularyImpl) {
 @Composable
 private fun QuizOptions(
     modifier: Modifier = Modifier,
-    options: List<VocabularyImpl>,
+    options: ImmutableList<VocabularyImpl>,
     onOptionClick: (Int) -> Unit
 ) {
     Column(
@@ -184,9 +185,7 @@ private fun QuizOption(
             .padding(4.dp),
     ) {
         CompositionLocalProvider(LocalTextStyle provides MaterialTheme.typography.h6) {
-            WordMeanings(
-                meanings = option.meaning.truncate(2),
-            )
+            WordMeanings(meanings = option.meaning.truncate(2).toImmutableList())
         }
     }
 }

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/quiz/QuizViewModel.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/quiz/QuizViewModel.kt
@@ -1,6 +1,5 @@
 package hsk.practice.myvoca.ui.screens.quiz
 
-import androidx.compose.runtime.Immutable
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.hsk.data.Vocabulary
@@ -14,6 +13,9 @@ import hsk.practice.myvoca.module.LocalVocaPersistence
 import hsk.practice.myvoca.room.vocabulary.toVocabularyImplList
 import hsk.practice.myvoca.util.MyVocaPreferencesKey
 import hsk.practice.myvoca.util.PreferencesDataStore
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -95,12 +97,12 @@ class QuizViewModel @Inject constructor(
         correct: Int,
         wrong: Int
     ): QuizScreenData {
-        val quizList = allVocabulary.randoms(quizSize).toVocabularyImplList()
+        val quizList = allVocabulary.randoms(quizSize).toVocabularyImplList().toImmutableList()
         val answerIndex = (0 until quizSize).random()
         return QuizScreenData(
             quizState = QuizAvailable,
             numberVocabularyNeed = vocabularyRequired - allVocabulary.size,
-            quiz = Quiz(quizList = quizList, answerIndex = answerIndex),
+            quiz = Quiz(quizWords = quizList, answerIndex = answerIndex),
             quizStat = QuizStat(correct, wrong)
         )
     }
@@ -142,22 +144,18 @@ sealed class QuizResult
 object QuizCorrect : QuizResult()
 object QuizWrong : QuizResult()
 
-@Immutable
 data class QuizResultData(val result: QuizResult, val answer: VocabularyImpl)
 
-@Immutable
 data class Quiz(
-    val quizList: List<VocabularyImpl> = emptyList(),
+    val quizWords: ImmutableList<VocabularyImpl> = persistentListOf(),
     val answerIndex: Int = 0
 ) {
     val answer: VocabularyImpl
-        get() = quizList[answerIndex]
+        get() = quizWords[answerIndex]
 }
 
-@Immutable
 data class QuizStat(val correct: Int = 0, val wrong: Int = 0)
 
-@Immutable
 data class QuizScreenData(
     val quizState: QuizState = QuizInit,
     val numberVocabularyNeed: Int = 0,

--- a/app/src/main/java/hsk/practice/myvoca/ui/structure/MyVocaApp.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/structure/MyVocaApp.kt
@@ -27,6 +27,7 @@ import hsk.practice.myvoca.ui.screens.profile.ProfileViewModel
 import hsk.practice.myvoca.ui.screens.quiz.QuizScreen
 import hsk.practice.myvoca.ui.screens.quiz.QuizViewModel
 import hsk.practice.myvoca.ui.theme.MyVocaTheme
+import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun MyVocaApp(onLaunch: suspend () -> Unit = {}) {
@@ -40,7 +41,7 @@ fun MyVocaApp(onLaunch: suspend () -> Unit = {}) {
             )
         }
 
-        val allScreens = MyVocaScreen.values().toList()
+        val allScreens = MyVocaScreen.values().toList().toImmutableList()
         val navController = rememberNavController()
         val backStackEntry by navController.currentBackStackEntryAsState()
         val currentScreen = MyVocaScreen.fromRoute(backStackEntry?.destination?.route)

--- a/app/src/test/java/hsk/practice/myvoca/TestSampleData.kt
+++ b/app/src/test/java/hsk/practice/myvoca/TestSampleData.kt
@@ -10,6 +10,7 @@ import hsk.practice.myvoca.data.WordClassImpl
 import hsk.practice.myvoca.room.todayword.RoomTodayWord
 import hsk.practice.myvoca.room.vocabulary.RoomVocabulary
 import hsk.practice.myvoca.room.vocabulary.toJson
+import kotlinx.collections.immutable.toImmutableList
 
 object TestSampleData {
     fun getSampleVoca(
@@ -59,7 +60,7 @@ object TestSampleData {
         return VocabularyImpl(
             id = id,
             eng = eng,
-            meaning = meaning,
+            meaning = meaning.toImmutableList(),
             addedTime = currentTime,
             lastEditedTime = currentTime,
             memo = memo

--- a/app/src/test/java/hsk/practice/myvoca/VocabularyQueryTest.kt
+++ b/app/src/test/java/hsk/practice/myvoca/VocabularyQueryTest.kt
@@ -5,6 +5,7 @@ import com.hsk.data.WordClass
 import com.hsk.data.matchesWithQuery
 import hsk.practice.myvoca.data.fakeData
 import hsk.practice.myvoca.room.vocabulary.toVocabulary
+import kotlinx.collections.immutable.persistentSetOf
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -29,13 +30,13 @@ class VocabularyQueryTest {
 
     @Test
     fun wordClassSingleQuery() {
-        val query = VocabularyQuery(wordClass = setOf(WordClass.NOUN))
+        val query = VocabularyQuery(wordClass = persistentSetOf(WordClass.NOUN))
         assertThat(data[1].matchesWithQuery(query)).isTrue
     }
 
     @Test
     fun wordClassQuery() {
-        val query = VocabularyQuery(wordClass = setOf(WordClass.NOUN))
+        val query = VocabularyQuery(wordClass = persistentSetOf(WordClass.NOUN))
         val expected = data.filter { it.meaning.any { meaning -> meaning.type == WordClass.NOUN } }
         val actual = data.filter { it.matchesWithQuery(query) }
         assertThat(actual).isEqualTo(expected)

--- a/app/src/test/java/hsk/practice/myvoca/ui/screens/addword/AddWordScreenDataTest.kt
+++ b/app/src/test/java/hsk/practice/myvoca/ui/screens/addword/AddWordScreenDataTest.kt
@@ -1,6 +1,7 @@
 package hsk.practice.myvoca.ui.screens.addword
 
 import hsk.practice.myvoca.data.MeaningImpl
+import kotlinx.collections.immutable.toImmutableList
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 
@@ -67,7 +68,7 @@ class AddWordScreenDataTest {
         val data = AddWordScreenData(
             word = word,
             wordExistStatus = wordExistStatus,
-            meanings = meanings
+            meanings = meanings.toImmutableList()
         )
         assertThat(data.canStoreWord).isEqualTo(expected)
     }

--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,27 @@ allprojects {
     }
 }
 
+subprojects {
+    tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).configureEach {
+        kotlinOptions {
+            if (project.findProperty("composeCompilerReports") == "true") {
+                freeCompilerArgs += [
+                        "-P",
+                        "plugin:androidx.compose.compiler.plugins.kotlin:reportsDestination=" +
+                                project.buildDir.absolutePath + "/compose_compiler"
+                ]
+            }
+            if (project.findProperty("composeCompilerMetrics") == "true") {
+                freeCompilerArgs += [
+                        "-P",
+                        "plugin:androidx.compose.compiler.plugins.kotlin:metricsDestination=" +
+                                project.buildDir.absolutePath + "/compose_compiler"
+                ]
+            }
+        }
+    }
+}
+
 task clean(type: Delete) {
     delete rootProject.buildDir
 }

--- a/data/build.gradle
+++ b/data/build.gradle
@@ -18,4 +18,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-jdk8:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-slf4j:$coroutines_version"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-debug:$coroutines_version"
+
+    // kotlin immutable collections
+    implementation "org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5"
 }

--- a/data/src/main/java/com/hsk/data/Vocabulary.kt
+++ b/data/src/main/java/com/hsk/data/Vocabulary.kt
@@ -1,5 +1,7 @@
 package com.hsk.data
 
+import kotlinx.collections.immutable.ImmutableSet
+import kotlinx.collections.immutable.persistentSetOf
 import java.io.Serializable
 
 data class Vocabulary(
@@ -64,5 +66,5 @@ enum class WordClass {
 
 data class VocabularyQuery(
     val word: String = "",
-    val wordClass: Set<WordClass> = emptySet()
+    val wordClass: ImmutableSet<WordClass> = persistentSetOf()
 )

--- a/domain/build.gradle
+++ b/domain/build.gradle
@@ -13,5 +13,8 @@ dependencies {
 
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.6.4'
 
+    // kotlin immutable collections
+    implementation "org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5"
+
     implementation project(':data')
 }


### PR DESCRIPTION
더 많은 Composable과 클래스를 skippable로 만들기 위해 Kotlin Immutable Collection을 적용했다.
## 예시
### Before
```
restartable fun MeaningsContent(
  unstable meanings: List<MeaningImpl>
  stable onMeaningUpdate: Function2<Int, MeaningImpl, Unit>
  stable onMeaningDelete: Function1<Int, Unit>
)
```

### After
```
restartable skippable fun MeaningsContent(
  stable meanings: ImmutableList<MeaningImpl>
  stable onMeaningUpdate: Function2<Int, MeaningImpl, Unit>
  stable onMeaningDelete: Function1<Int, Unit>
)
```