### PR TITLE
실패하는 테스트 고침

### DIFF
--- a/app/src/main/java/hsk/practice/myvoca/room/persistence/FakeTodayWordPersistence.kt
+++ b/app/src/main/java/hsk/practice/myvoca/room/persistence/FakeTodayWordPersistence.kt
@@ -4,7 +4,12 @@ import com.hsk.data.TodayWord
 import com.hsk.data.Vocabulary
 import com.hsk.domain.TodayWordPersistence
 import com.hsk.domain.VocaPersistence
+import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.mutate
+import kotlinx.collections.immutable.persistentListOf
+import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
@@ -12,44 +17,63 @@ class FakeTodayWordPersistence @Inject constructor(
     private val vocaPersistence: VocaPersistence
 ) : TodayWordPersistence {
 
-    private val todayWords = mutableSetOf<TodayWord>()
+    private val todayWordsFlow = MutableStateFlow(persistentListOf<TodayWord>())
+    private val todayWords: ImmutableList<TodayWord>
+        get() = todayWordsFlow.value.toImmutableList()
 
-    override fun loadTodayWords(): Flow<List<TodayWord>> = flow {
-        emit(todayWords.toList())
-    }
+    override fun loadTodayWords(): Flow<List<TodayWord>> = todayWordsFlow
 
     override fun loadActualTodayWords(): Flow<List<Vocabulary>> = flow {
         todayWords.map { vocaPersistence.getVocabularyById(it.wordId) }
     }
 
     override suspend fun insertTodayWord(newTodayWord: TodayWord) {
-        todayWords.add(newTodayWord)
+        updateValue {
+            add(newTodayWord)
+        }
     }
 
     override suspend fun insertTodayWords(newTodayWords: List<TodayWord>) {
-        todayWords.addAll(newTodayWords)
+        updateValue {
+            addAll(newTodayWords)
+        }
     }
 
     override suspend fun updateTodayWord(todayWord: TodayWord) =
         onlyWhenExists(todayWord) { target ->
-            todayWords.removeAll { it.todayId == target.todayId }
-            todayWords.add(target)
+            updateValue {
+                removeAll { it.todayId == target.todayId }
+                add(target)
+            }
         }
 
     override suspend fun deleteTodayWord(todayWord: TodayWord) =
         onlyWhenExists(todayWord) { target ->
-            todayWords.remove(target)
+            updateValue {
+                remove(target)
+            }
         }
 
     override suspend fun clearTodayWords() {
-        todayWords.clear()
+        updateValue {
+            clear()
+        }
     }
 
-    private fun onlyWhenExists(todayWord: TodayWord, block: (TodayWord) -> Unit) {
+    private suspend fun onlyWhenExists(todayWord: TodayWord, block: suspend (TodayWord) -> Unit) {
         if (todayWords.any { it.todayId == todayWord.todayId }) {
             block(todayWord)
         } else {
             throw NoSuchElementException("$todayWord doesn't exist. Exists: $todayWords")
         }
+    }
+
+    /**
+     * All functions which desire to modify flow's value should only use this function.
+     * Any other changes are invalid.
+     */
+    private fun updateValue(action: MutableList<TodayWord>.() -> Unit) {
+        val newValue = todayWordsFlow.value.mutate { action(it) }
+        todayWordsFlow.value = newValue
     }
 }

--- a/app/src/main/java/hsk/practice/myvoca/room/persistence/FakeTodayWordPersistence.kt
+++ b/app/src/main/java/hsk/practice/myvoca/room/persistence/FakeTodayWordPersistence.kt
@@ -3,28 +3,23 @@ package hsk.practice.myvoca.room.persistence
 import com.hsk.data.TodayWord
 import com.hsk.data.Vocabulary
 import com.hsk.domain.TodayWordPersistence
+import com.hsk.domain.VocaPersistence
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
-class FakeTodayWordPersistence @Inject constructor() : TodayWordPersistence {
+class FakeTodayWordPersistence @Inject constructor(
+    private val vocaPersistence: VocaPersistence
+) : TodayWordPersistence {
 
-    private val fakeVocaPersistence = FakeVocaPersistence()
+    private val todayWords = mutableSetOf<TodayWord>()
 
-    private val todayWords = mutableListOf<TodayWord>()
-    private val fakeTodayWordFlow = MutableStateFlow(todayWords)
-
-    override fun loadTodayWords(): Flow<List<TodayWord>> {
-        return fakeTodayWordFlow
+    override fun loadTodayWords(): Flow<List<TodayWord>> = flow {
+        emit(todayWords.toList())
     }
 
-    override fun loadActualTodayWords(): Flow<List<Vocabulary>> {
-        return flow {
-            todayWords.map { todayWord ->
-                fakeVocaPersistence.getVocabularyById(todayWord.wordId)
-            }
-        }
+    override fun loadActualTodayWords(): Flow<List<Vocabulary>> = flow {
+        todayWords.map { vocaPersistence.getVocabularyById(it.wordId) }
     }
 
     override suspend fun insertTodayWord(newTodayWord: TodayWord) {
@@ -35,29 +30,26 @@ class FakeTodayWordPersistence @Inject constructor() : TodayWordPersistence {
         todayWords.addAll(newTodayWords)
     }
 
-    override suspend fun updateTodayWord(todayWord: TodayWord) {
-        val index = findIndex(todayWord)
-        if (index == -1) {
-            throw NoSuchElementException("$todayWord doesn't exist.")
-        } else {
-            todayWords[index] = todayWord
+    override suspend fun updateTodayWord(todayWord: TodayWord) =
+        onlyWhenExists(todayWord) { target ->
+            todayWords.removeAll { it.todayId == target.todayId }
+            todayWords.add(target)
         }
-    }
 
-    override suspend fun deleteTodayWord(todayWord: TodayWord) {
-        val index = findIndex(todayWord)
-        if (index == -1) {
-            throw NoSuchElementException("$todayWord doesn't exist.")
-        } else {
-            todayWords.removeAt(index)
+    override suspend fun deleteTodayWord(todayWord: TodayWord) =
+        onlyWhenExists(todayWord) { target ->
+            todayWords.remove(target)
         }
-    }
-
-    private fun findIndex(todayWord: TodayWord): Int {
-        return todayWords.indexOfFirst { it.todayId == todayWord.todayId }
-    }
 
     override suspend fun clearTodayWords() {
         todayWords.clear()
+    }
+
+    private fun onlyWhenExists(todayWord: TodayWord, block: (TodayWord) -> Unit) {
+        if (todayWords.any { it.todayId == todayWord.todayId }) {
+            block(todayWord)
+        } else {
+            throw NoSuchElementException("$todayWord doesn't exist. Exists: $todayWords")
+        }
     }
 }

--- a/app/src/main/java/hsk/practice/myvoca/room/persistence/FakeTodayWordPersistence.kt
+++ b/app/src/main/java/hsk/practice/myvoca/room/persistence/FakeTodayWordPersistence.kt
@@ -27,12 +27,12 @@ class FakeTodayWordPersistence @Inject constructor() : TodayWordPersistence {
         }
     }
 
-    override suspend fun insertTodayWord(todayWord: TodayWord) {
-        todayWords.add(todayWord)
+    override suspend fun insertTodayWord(newTodayWord: TodayWord) {
+        todayWords.add(newTodayWord)
     }
 
-    override suspend fun insertTodayWords(todayWords: List<TodayWord>) {
-        todayWords.forEach { insertTodayWord(it) }
+    override suspend fun insertTodayWords(newTodayWords: List<TodayWord>) {
+        todayWords.addAll(newTodayWords)
     }
 
     override suspend fun updateTodayWord(todayWord: TodayWord) {

--- a/app/src/main/java/hsk/practice/myvoca/room/persistence/FakeVocaPersistence.kt
+++ b/app/src/main/java/hsk/practice/myvoca/room/persistence/FakeVocaPersistence.kt
@@ -35,7 +35,7 @@ class FakeVocaPersistence @Inject constructor() : VocaPersistence, CoroutineScop
         return try {
             data.first { it.id == id }
         } catch (e: NoSuchElementException) {
-            throw VocaPersistenceException("id $id doesn't exist")
+            throw VocaPersistenceException("id $id doesn't exist. All: $data")
         }
     }
 

--- a/app/src/main/java/hsk/practice/myvoca/room/persistence/TodayWordPersistenceRoom.kt
+++ b/app/src/main/java/hsk/practice/myvoca/room/persistence/TodayWordPersistenceRoom.kt
@@ -75,12 +75,12 @@ class TodayWordPersistenceRoom @Inject constructor(@ApplicationContext context: 
     override fun loadActualTodayWords(): Flow<List<Vocabulary>> =
         vocaDao.getTodayWords().distinctUntilChanged().map { it.toVocabularyList() }
 
-    override suspend fun insertTodayWord(todayWord: TodayWord) {
-        todayWordDao.insertTodayWord(todayWord.toRoomTodayWord())
+    override suspend fun insertTodayWord(newTodayWord: TodayWord) {
+        todayWordDao.insertTodayWord(newTodayWord.toRoomTodayWord())
     }
 
-    override suspend fun insertTodayWords(todayWords: List<TodayWord>) {
-        todayWordDao.insertTodayWord(todayWords.map { it.toRoomTodayWord() })
+    override suspend fun insertTodayWords(newTodayWords: List<TodayWord>) {
+        todayWordDao.insertTodayWord(newTodayWords.map { it.toRoomTodayWord() })
     }
 
     override suspend fun updateTodayWord(todayWord: TodayWord) {

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/home/HomeViewModel.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/home/HomeViewModel.kt
@@ -24,7 +24,6 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
@@ -98,10 +97,10 @@ class HomeViewModel @Inject constructor(
         setOneTimeTodayWordWork(workManager)
     }
 
-    fun onTodayWordCheckboxChange(homeTodayWord: HomeTodayWord): Job {
+    fun onTodayWordCheckboxChange(homeTodayWord: HomeTodayWord) {
         val checked = homeTodayWord.todayWord.checked
         val copy = homeTodayWord.todayWord.copy(checked = !checked)
-        return viewModelScope.launch(ioDispatcher) {
+        viewModelScope.launch(ioDispatcher) {
             todayWordPersistence.updateTodayWord(copy.toTodayWord())
         }
     }

--- a/app/src/test/java/hsk/practice/myvoca/MainCoroutineExtension.kt
+++ b/app/src/test/java/hsk/practice/myvoca/MainCoroutineExtension.kt
@@ -10,6 +10,9 @@ import org.junit.jupiter.api.extension.AfterEachCallback
 import org.junit.jupiter.api.extension.BeforeEachCallback
 import org.junit.jupiter.api.extension.ExtensionContext
 
+/**
+ * Coroutine extension for JUnit5
+ */
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainCoroutineExtension(private val dispatcher: TestDispatcher) :
     BeforeEachCallback, AfterEachCallback {

--- a/app/src/test/java/hsk/practice/myvoca/MainCoroutineRule.kt
+++ b/app/src/test/java/hsk/practice/myvoca/MainCoroutineRule.kt
@@ -1,16 +1,18 @@
 package hsk.practice.myvoca
 
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.cancel
+import kotlinx.coroutines.*
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
+import org.junit.runners.model.Statement
+import kotlin.coroutines.CoroutineContext
 
 @OptIn(ExperimentalCoroutinesApi::class)
-class MainCoroutineRule(private val dispatcher: TestDispatcher) : TestWatcher() {
+class MainCoroutineRule(private val dispatcher: TestDispatcher) : TestWatcher(), CoroutineScope {
+    override val coroutineContext: CoroutineContext = dispatcher + Job()
+
     override fun starting(description: Description?) {
         super.starting(description)
         Dispatchers.setMain(dispatcher)
@@ -20,5 +22,11 @@ class MainCoroutineRule(private val dispatcher: TestDispatcher) : TestWatcher() 
         super.finished(description)
         Dispatchers.resetMain()
         dispatcher.cancel()
+    }
+
+    override fun apply(base: Statement?, description: Description?) = object : Statement() {
+        override fun evaluate() {
+            this@MainCoroutineRule.cancel()
+        }
     }
 }

--- a/app/src/test/java/hsk/practice/myvoca/MainCoroutineRule.kt
+++ b/app/src/test/java/hsk/practice/myvoca/MainCoroutineRule.kt
@@ -1,12 +1,13 @@
 package hsk.practice.myvoca
 
-import kotlinx.coroutines.*
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.rules.TestWatcher
 import org.junit.runner.Description
-import kotlin.coroutines.CoroutineContext
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainCoroutineRule(private val dispatcher: TestDispatcher) : TestWatcher() {
@@ -20,14 +21,4 @@ class MainCoroutineRule(private val dispatcher: TestDispatcher) : TestWatcher() 
         Dispatchers.resetMain()
         dispatcher.cancel()
     }
-}
-
-suspend fun <T> withDelay(
-    context: CoroutineContext,
-    delayMilli: Long = 100L,
-    block: suspend CoroutineScope.() -> T
-): T = withContext(context) {
-    val result = block()
-    delay(delayMilli)
-    return@withContext result
 }

--- a/app/src/test/java/hsk/practice/myvoca/MainCoroutineRule.kt
+++ b/app/src/test/java/hsk/practice/myvoca/MainCoroutineRule.kt
@@ -9,6 +9,9 @@ import org.junit.runner.Description
 import org.junit.runners.model.Statement
 import kotlin.coroutines.CoroutineContext
 
+/**
+ * Coroutine Rule for JUnit4
+ */
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainCoroutineRule(private val dispatcher: TestDispatcher) : TestWatcher(), CoroutineScope {
     override val coroutineContext: CoroutineContext = dispatcher + Job()

--- a/app/src/test/java/hsk/practice/myvoca/TestSampleData.kt
+++ b/app/src/test/java/hsk/practice/myvoca/TestSampleData.kt
@@ -25,7 +25,7 @@ object TestSampleData {
         memo = memo
     )
 
-    fun getSampleVocabularies() = (3..10).map {
+    fun getSampleVocabularies() = (1..10).map {
         getSampleVoca(id = it)
     }
 

--- a/app/src/test/java/hsk/practice/myvoca/room/persistence/TodayWordPersistenceTest.kt
+++ b/app/src/test/java/hsk/practice/myvoca/room/persistence/TodayWordPersistenceTest.kt
@@ -23,7 +23,7 @@ class TodayWordPersistenceTest {
     val coroutineExtension = MainCoroutineExtension(dispatcher)
 
     // Any subclass of TodayWordPersistence
-    private val persistence: TodayWordPersistence = FakeTodayWordPersistence()
+    private val persistence: TodayWordPersistence = FakeTodayWordPersistence(FakeVocaPersistence())
 
     @BeforeEach
     fun initTest() = runTest {

--- a/app/src/test/java/hsk/practice/myvoca/room/persistence/TodayWordPersistenceTest.kt
+++ b/app/src/test/java/hsk/practice/myvoca/room/persistence/TodayWordPersistenceTest.kt
@@ -39,14 +39,14 @@ class TodayWordPersistenceTest {
     fun insertTodayWord_NormalCase() = runTest {
         val sample = getSampleTodayWord()
         persistence.insertTodayWord(sample)
-        assertThat(loadTodayWordsFlowFirst()).containsOnly(sample)
+        assertThat(getTodayWord()).containsOnly(sample)
     }
 
     @Test
     fun insertTodayWords_NormalCase() = runTest {
         val samples = getSampleTodayWords()
         persistence.insertTodayWords(samples)
-        assertThat(loadTodayWordsFlowFirst()).isEqualTo(samples)
+        assertThat(getTodayWord()).isEqualTo(samples)
     }
 
     @Test
@@ -64,7 +64,7 @@ class TodayWordPersistenceTest {
 
         val checkedSamples = samples.map { todayWord -> todayWord.copy(checked = true) }
             .onEach { sample -> persistence.updateTodayWord(sample) }
-        assertThat(loadTodayWordsFlowFirst()).isEqualTo(checkedSamples)
+        assertThat(getTodayWord()).isEqualTo(checkedSamples)
     }
 
     @Test
@@ -73,7 +73,7 @@ class TodayWordPersistenceTest {
         persistence.insertTodayWord(sample)
         persistence.deleteTodayWord(sample)
 
-        assertThat(loadTodayWordsFlowFirst()).isEmpty()
+        assertThat(getTodayWord()).isEmpty()
     }
 
     @Test
@@ -84,6 +84,6 @@ class TodayWordPersistenceTest {
         }
     }
 
-    private suspend fun loadTodayWordsFlowFirst() = persistence.loadTodayWords().first()
+    private suspend fun getTodayWord() = persistence.loadTodayWords().first()
 
 }

--- a/app/src/test/java/hsk/practice/myvoca/ui/screens/addword/AddWordViewModelTest.kt
+++ b/app/src/test/java/hsk/practice/myvoca/ui/screens/addword/AddWordViewModelTest.kt
@@ -54,6 +54,7 @@ class AddWordViewModelTest {
         assertThat(uiState.word).isEqualTo(sample.eng)
     }
 
+    // TODO: fix exception
     @Test
     fun injectUpdateWord_InjectNotExistWord() = runBlocking {
         injectUpdateWordThenDelay(1)

--- a/app/src/test/java/hsk/practice/myvoca/ui/screens/addword/AddWordViewModelTest.kt
+++ b/app/src/test/java/hsk/practice/myvoca/ui/screens/addword/AddWordViewModelTest.kt
@@ -54,12 +54,13 @@ class AddWordViewModelTest {
         assertThat(uiState.word).isEqualTo(sample.eng)
     }
 
-    // TODO: fix exception
     @Test
-    fun injectUpdateWord_InjectNotExistWord() = runBlocking {
-        injectUpdateWordThenDelay(1)
-        assertThat(uiState.word).isEmpty()
-    }
+    fun injectUpdateWord_InjectNotExistWord(): Unit = runTest {
+        val sample = vocaPersistence.insertTestData()[0]
+        viewModel.injectUpdateTarget(sample.id)
+        assertDoesNotThrow {
+            viewModel.uiStateFlow.first { it.word.isNotEmpty() }
+        }
 
     private suspend fun injectUpdateWordThenDelay(wordId: Int) = delayAfter {
         viewModel.injectUpdateTarget(wordId)
@@ -312,6 +313,12 @@ class AddWordViewModelTest {
 
     private suspend fun onAddWordThenDelay() = delayAfter {
         viewModel.onAddWord()
+    }
+
+    private suspend fun VocaPersistence.insertTestData(): List<Vocabulary> {
+        val sampleData = TestSampleData.getSampleVocabularies()
+        insertVocabulary(sampleData)
+        return sampleData
     }
 
 }

--- a/app/src/test/java/hsk/practice/myvoca/ui/screens/home/HomeViewModelTest.kt
+++ b/app/src/test/java/hsk/practice/myvoca/ui/screens/home/HomeViewModelTest.kt
@@ -13,12 +13,8 @@ import hsk.practice.myvoca.room.persistence.FakeTodayWordPersistence
 import hsk.practice.myvoca.room.persistence.FakeVocaPersistence
 import hsk.practice.myvoca.util.PreferencesDataStore
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.take
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.StandardTestDispatcher
-import kotlinx.coroutines.test.TestScope
 import kotlinx.coroutines.test.runTest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.Before
@@ -35,7 +31,6 @@ import org.robolectric.annotation.Config
 class HomeViewModelTest {
 
     private val testDispatcher = StandardTestDispatcher()
-    private val testScope = TestScope(testDispatcher + Job())
     private val vocaPersistence: VocaPersistence = FakeVocaPersistence()
     private val todayWordPersistence: TodayWordPersistence =
         FakeTodayWordPersistence(vocaPersistence)
@@ -56,7 +51,7 @@ class HomeViewModelTest {
     }
 
     @Before
-    fun setUp() = runBlocking {
+    fun setUp() = runTest {
         vocaPersistence.clearVocabulary()
         todayWordPersistence.clearTodayWords()
         viewModel = HomeViewModel(
@@ -83,7 +78,7 @@ class HomeViewModelTest {
     }
 
     @Test
-    fun onTodayWordCheckboxChange_CheckPersistence() = testScope.runTest {
+    fun onTodayWordCheckboxChange_CheckPersistence() = runTest {
         vocaPersistence.insertVocabulary(TestSampleData.getSampleVocabularies())
         val sample = TestSampleData.getSampleTodayWord()
         todayWordPersistence.insertTodayWord(sample)
@@ -92,9 +87,9 @@ class HomeViewModelTest {
                 sample.toTodayWordImpl(),
                 TestSampleData.getSampleVocaImpl()
             )
-        ).join()
+        )
         assertDoesNotThrow {
-            todayWordPersistence.loadTodayWords().take(2).first { candidate ->
+            todayWordPersistence.loadTodayWords().first { candidate ->
                 candidate.any { it.todayId == sample.todayId && it.checked != sample.checked }
             }
         }

--- a/domain/src/main/java/com/hsk/domain/TodayWordPersistence.kt
+++ b/domain/src/main/java/com/hsk/domain/TodayWordPersistence.kt
@@ -10,9 +10,9 @@ interface TodayWordPersistence {
 
     fun loadActualTodayWords(): Flow<List<Vocabulary>>
 
-    suspend fun insertTodayWord(todayWord: TodayWord)
+    suspend fun insertTodayWord(newTodayWord: TodayWord)
 
-    suspend fun insertTodayWords(todayWords: List<TodayWord>)
+    suspend fun insertTodayWords(newTodayWords: List<TodayWord>)
 
     suspend fun updateTodayWord(todayWord: TodayWord)
 


### PR DESCRIPTION
코루틴의 비동기성 때문에 실패하던 테스트를 고쳤다. 

핵심은 갱신될 값을 기다릴 때 특정 시간 기다리지 않고 값 자체를 조건으로 하여 기다리는 것. ``Flow<T>.first`` 함수 등을 이용하면 좋다.