### PR TITLE
단어 검색 화면 내에 웹뷰 추가 

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -165,7 +165,9 @@ dependencies {
     // Integration with activities
     implementation 'androidx.activity:activity-compose:1.8.0'
     // Integration with ViewModels
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0-alpha03'
+    implementation 'androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0-beta01'
+    // Integration with Runtime
+    implementation 'androidx.lifecycle:lifecycle-runtime-compose:2.7.0-beta01'
     // Integration with Hilt
     implementation "androidx.hilt:hilt-navigation-compose:1.0.0"
     // UI Tests
@@ -272,7 +274,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5"
 
     // Accompanist WebView
-    implementation "com.google.accompanist:accompanist-webview:0.31.3-beta"    
+    implementation "com.google.accompanist:accompanist-webview:0.31.3-beta"
 
     implementation project(':data')
     implementation project(':domain')

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -271,6 +271,9 @@ dependencies {
     // kotlin immutable collections
     implementation "org.jetbrains.kotlinx:kotlinx-collections-immutable:0.3.5"
 
+    // Accompanist WebView
+    implementation "com.google.accompanist:accompanist-webview:0.31.3-beta"    
+
     implementation project(':data')
     implementation project(':domain')
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
     <uses-permission
         android:name="com.google.android.gms.permission.AD_ID"
         tools:node="remove" />
+    <uses-permission android:name="android.permission.INTERNET" />
 
     <application
         android:name=".app.MyVocaApplication"

--- a/app/src/main/java/hsk/practice/myvoca/ui/components/Text.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/components/Text.kt
@@ -1,0 +1,58 @@
+package hsk.practice.myvoca.ui.components
+
+import androidx.compose.material3.LocalTextStyle
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.TextLayoutResult
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextDecoration
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.TextUnit
+import hsk.practice.myvoca.ui.theme.Paybooc
+
+@Composable
+fun MyVocaText(
+    text: String,
+    modifier: Modifier = Modifier,
+    color: Color = Color.Unspecified,
+    fontSize: TextUnit = TextUnit.Unspecified,
+    fontStyle: FontStyle? = null,
+    fontWeight: FontWeight? = null,
+    fontFamily: FontFamily = Paybooc,
+    letterSpacing: TextUnit = TextUnit.Unspecified,
+    textDecoration: TextDecoration? = null,
+    textAlign: TextAlign? = null,
+    lineHeight: TextUnit = TextUnit.Unspecified,
+    overflow: TextOverflow = TextOverflow.Clip,
+    softWrap: Boolean = true,
+    maxLines: Int = Int.MAX_VALUE,
+    minLines: Int = 1,
+    onTextLayout: (TextLayoutResult) -> Unit = {},
+    style: TextStyle = LocalTextStyle.current
+) {
+    Text(
+        text = text,
+        modifier = modifier,
+        color = color,
+        fontSize = fontSize,
+        fontStyle = fontStyle,
+        fontWeight = fontWeight,
+        fontFamily = fontFamily,
+        letterSpacing = letterSpacing,
+        textDecoration = textDecoration,
+        textAlign = textAlign,
+        lineHeight = lineHeight,
+        overflow = overflow,
+        softWrap = softWrap,
+        maxLines = maxLines,
+        minLines = minLines,
+        onTextLayout = onTextLayout,
+        style = style
+    )
+}

--- a/app/src/main/java/hsk/practice/myvoca/ui/components/TopAppBar.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/components/TopAppBar.kt
@@ -11,7 +11,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
@@ -23,7 +22,6 @@ import hsk.practice.myvoca.R
 import hsk.practice.myvoca.ui.screens.addword.AddWordActivity
 import hsk.practice.myvoca.ui.structure.MyVocaScreen
 import hsk.practice.myvoca.ui.theme.MyVocaTheme
-import hsk.practice.myvoca.ui.theme.Paybooc
 import kotlinx.coroutines.launch
 
 @Composable
@@ -43,9 +41,8 @@ fun MyVocaTopAppBar(currentScreen: MyVocaScreen) {
 
 @Composable
 private fun MyVocaTopTitle() {
-    Text(
+    MyVocaText(
         text = stringResource(R.string.app_name),
-        fontFamily = Paybooc,
         color = MaterialTheme.colorScheme.onSurface,
         style = MaterialTheme.typography.headlineSmall,
     )

--- a/app/src/main/java/hsk/practice/myvoca/ui/components/WordContent.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/components/WordContent.kt
@@ -86,10 +86,9 @@ fun WordTitle(
     title: String,
     modifier: Modifier = Modifier
 ) {
-    Text(
+    MyVocaText(
         modifier = modifier,
         text = title,
-        fontFamily = Paybooc,
         style = MaterialTheme.typography.headlineSmall,
     )
 }
@@ -175,10 +174,7 @@ fun WordMeaning(
             },
             fontFamily = Paybooc
         )
-        Text(
-            text = meaning.content,
-            fontFamily = Paybooc
-        )
+        MyVocaText(text = meaning.content)
     }
 }
 

--- a/app/src/main/java/hsk/practice/myvoca/ui/components/versus/VersusView.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/components/versus/VersusView.kt
@@ -11,7 +11,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
@@ -27,7 +26,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.hsk.ktx.gcd
-import hsk.practice.myvoca.ui.theme.Paybooc
+import hsk.practice.myvoca.ui.components.MyVocaText
 
 fun VersusViewState(
     leftValue: Int = 0,
@@ -124,9 +123,8 @@ fun VersusElement(
                 )
             )
     ) {
-        Text(
+        MyVocaText(
             text = value.toString(),
-            fontFamily = Paybooc,
             modifier = Modifier
                 .padding(horizontal = 4.dp)
                 .align(align),

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordScreen.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordScreen.kt
@@ -42,6 +42,7 @@ import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.google.accompanist.web.WebView
 import hsk.practice.myvoca.data.MeaningImpl
 import hsk.practice.myvoca.data.WordClassImpl
@@ -64,7 +65,7 @@ fun AddWordScreen(
         if (updateWordId != -1) viewModel.injectUpdateTarget(updateWordId)
     }
 
-    val uiState by viewModel.uiStateFlow.collectAsState()
+    val uiState by viewModel.uiStateFlow.collectAsStateWithLifecycle()
 
     Scaffold(
         modifier = modifier,

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordScreen.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordScreen.kt
@@ -80,6 +80,8 @@ fun AddWordScreen(
                 screenType = uiState.screenType,
                 addButtonEnabled = uiState.canStoreWord,
                 onAddWord = viewModel::onAddWord,
+                showWebView = uiState.showWebView,
+                onHideWebView = viewModel::onHideWebView,
                 onClose = onClose
             )
         }
@@ -98,7 +100,7 @@ fun AddWordScreen(
                 onMeaningUpdate = viewModel::onMeaningUpdate,
                 onMeaningDelete = viewModel::onMeaningDelete,
                 onMemoUpdate = viewModel::onMemoUpdate,
-                onShowWebView = viewModel::onShowWordSearchWebView,
+                onShowWebView = viewModel::onShowWebView,
                 onUpdateWebViewUrl = viewModel::onUpdateWebViewUrl
             )
 
@@ -130,6 +132,8 @@ private fun TopBar(
     screenType: ScreenType,
     addButtonEnabled: Boolean,
     onAddWord: () -> Unit,
+    showWebView: Boolean,
+    onHideWebView: () -> Unit,
     onClose: () -> Unit
 ) {
     val textAlpha by animateFloatAsState(targetValue = if (addButtonEnabled) 1f else 0.6f)
@@ -142,12 +146,19 @@ private fun TopBar(
         },
         backgroundColor = MaterialTheme.colorScheme.secondary,
         actions = {
-            TopBarSaveButton(
-                onAddWord = onAddWord,
-                onClose = onClose,
-                addButtonEnabled = addButtonEnabled,
-                textColor = Color.White.copy(alpha = textAlpha)
-            )
+            if (showWebView) {
+                TopBarCompleteButton(
+                    textColor = Color.White,
+                    onHideWebView = onHideWebView
+                )
+            } else {
+                TopBarSaveButton(
+                    onAddWord = onAddWord,
+                    onClose = onClose,
+                    addButtonEnabled = addButtonEnabled,
+                    textColor = Color.White.copy(alpha = textAlpha)
+                )
+            }
         }
     )
 }
@@ -189,6 +200,25 @@ private fun TopBarSaveButton(
     ) {
         MyVocaText(
             text = "저장",
+            color = textColor
+        )
+    }
+}
+
+@Composable
+private fun TopBarCompleteButton(
+    textColor: Color,
+    onHideWebView: () -> Unit,
+    focusManager: FocusManager = LocalFocusManager.current,
+) {
+    TextButton(
+        onClick = {
+            focusManager.clearFocus()
+            onHideWebView()
+        },
+    ) {
+        MyVocaText(
+            text = "완료",
             color = textColor
         )
     }
@@ -608,6 +638,8 @@ private fun TopBarPreview() {
             screenType = AddWord,
             addButtonEnabled = buttonEnabled,
             onAddWord = { buttonEnabled = !buttonEnabled },
+            showWebView = false,
+            onHideWebView = {},
             onClose = {}
         )
     }

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordScreen.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordScreen.kt
@@ -66,6 +66,12 @@ fun AddWordScreen(
     }
 
     val uiState by viewModel.uiStateFlow.collectAsStateWithLifecycle()
+    val webViewState = viewModel.webViewState
+    val webViewNavigator = viewModel.webViewNavigator
+
+    LaunchedEffect(key1 = uiState.webViewUrl) {
+        webViewNavigator.loadUrl(uiState.webViewUrl)
+    }
 
     Scaffold(
         modifier = modifier,
@@ -93,12 +99,13 @@ fun AddWordScreen(
                 onMeaningDelete = viewModel::onMeaningDelete,
                 onMemoUpdate = viewModel::onMemoUpdate,
                 onShowWebView = viewModel::onShowWordSearchWebView,
-                onUpdateWordSearchWebViewUrl = viewModel::onUpdateWordSearchWebViewUrl
+                onUpdateWebViewUrl = viewModel::onUpdateWebViewUrl
             )
 
             if (uiState.showWebView) {
                 WebView(
-                    state = viewModel.webViewState.value,
+                    state = webViewState,
+                    navigator = webViewNavigator,
                     onCreated = { webView ->
                         with(webView) {
                             settings.run {
@@ -197,7 +204,7 @@ private fun Content(
     onMeaningDelete: (Int) -> Unit,
     onMemoUpdate: (String) -> Unit,
     onShowWebView: () -> Unit,
-    onUpdateWordSearchWebViewUrl: () -> Unit,
+    onUpdateWebViewUrl: () -> Unit,
 ) {
     Column(
         modifier = Modifier
@@ -213,7 +220,7 @@ private fun Content(
             loadStatus = loadStatus,
             onWordUpdate = onWordUpdate,
             onShowWebView = onShowWebView,
-            onUpdateWordSearchWebViewUrl = onUpdateWordSearchWebViewUrl
+            onUpdateWebViewUrl = onUpdateWebViewUrl
         )
         Meanings(
             meanings = data.meanings,
@@ -253,7 +260,7 @@ private fun Word(
     loadStatus: suspend (String) -> Unit,
     onWordUpdate: (String) -> Unit,
     onShowWebView: () -> Unit,
-    onUpdateWordSearchWebViewUrl: () -> Unit,
+    onUpdateWebViewUrl: () -> Unit,
     focusManager: FocusManager = LocalFocusManager.current
 ) {
     LaunchedEffect(word) {
@@ -313,7 +320,7 @@ private fun Word(
             IconButton(
                 onClick = {
                     onShowWebView()
-                    onUpdateWordSearchWebViewUrl()
+                    onUpdateWebViewUrl()
                 }
             ) {
                 Icon(
@@ -572,7 +579,7 @@ private fun AddWordScreenPreview() {
                 onMeaningDelete = {},
                 onMemoUpdate = {},
                 onShowWebView = {},
-                onUpdateWordSearchWebViewUrl = {}
+                onUpdateWebViewUrl = {}
             )
         }
     }

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordScreen.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordScreen.kt
@@ -27,7 +27,6 @@ import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
-import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
@@ -44,10 +43,10 @@ import androidx.compose.ui.unit.dp
 import hsk.practice.myvoca.data.MeaningImpl
 import hsk.practice.myvoca.data.WordClassImpl
 import hsk.practice.myvoca.ui.components.InsetAwareTopAppBar
+import hsk.practice.myvoca.ui.components.MyVocaText
 import hsk.practice.myvoca.ui.components.StaggeredGrid
 import hsk.practice.myvoca.ui.components.SystemBarColor
 import hsk.practice.myvoca.ui.theme.MyVocaTheme
-import hsk.practice.myvoca.ui.theme.Paybooc
 import kotlinx.collections.immutable.ImmutableList
 
 @Composable
@@ -125,10 +124,7 @@ private fun TopBarTitle(screenType: ScreenType) {
         AddWord -> "단어 추가"
         UpdateWord -> "단어 수정"
     }
-    Text(
-        text = title,
-        fontFamily = Paybooc
-    )
+    MyVocaText(text = title)
 }
 
 @Composable
@@ -157,7 +153,7 @@ private fun TopBarSaveButton(
         },
         enabled = addButtonEnabled
     ) {
-        Text(
+        MyVocaText(
             text = "저장",
             color = textColor
         )
@@ -199,18 +195,16 @@ private fun Content(
 
 @Composable
 private fun EssentialTitle() {
-    Text(
+    MyVocaText(
         text = "필수 입력사항",
-        fontFamily = Paybooc,
         style = MaterialTheme.typography.headlineSmall
     )
 }
 
 @Composable
 private fun OptionalTitle() {
-    Text(
+    MyVocaText(
         text = "선택 입력사항",
-        fontFamily = Paybooc,
         style = MaterialTheme.typography.headlineSmall
     )
 }
@@ -242,7 +236,7 @@ private fun Word(
         TextField(
             modifier = Modifier.fillMaxWidth(),
             value = word,
-            label = { Text("단어") },
+            label = { MyVocaText(text = "단어") },
             onValueChange = onWordUpdate,
             colors = textFieldColors,
             trailingIcon = {
@@ -265,7 +259,7 @@ private fun Word(
                 durationMillis = 300,
             )
         )
-        Text(
+        MyVocaText(
             text = "이미 등록된 단어입니다.",
             style = MaterialTheme.typography.bodySmall,
             color = duplicateTextColor
@@ -356,7 +350,7 @@ private fun WordClassChipIcon(
 
 @Composable
 private fun WordClassChipText(wordClass: WordClassImpl) {
-    Text(
+    MyVocaText(
         text = wordClass.korean,
         modifier = Modifier.padding(end = 4.dp)
     )
@@ -378,7 +372,7 @@ private fun MeaningsEmptyIndicator() {
                 imageVector = Icons.Outlined.Add,
                 contentDescription = null
             )
-            Text(
+            MyVocaText(
                 text = "뜻을 추가해 보세요",
                 color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.8f)
             )
@@ -432,7 +426,7 @@ private fun Meaning(
             modifier = Modifier.weight(1f),
             value = meaning.content,
             label = {
-                Text(text = "${index + 1}. ${meaning.type.korean}")
+                MyVocaText(text = "${index + 1}. ${meaning.type.korean}")
             },
             colors = textFieldColors,
             onValueChange = {
@@ -468,10 +462,7 @@ private fun Memo(
         modifier = Modifier.fillMaxWidth(),
         value = memo,
         label = {
-            Text(
-                text = "메모",
-                fontFamily = Paybooc
-            )
+            MyVocaText(text = "메모")
         },
         colors = textFieldColors,
         onValueChange = onMemoUpdate,

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordScreen.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordScreen.kt
@@ -349,6 +349,7 @@ private fun Word(
             }
             IconButton(
                 onClick = {
+                    focusManager.clearFocus()
                     onShowWebView()
                     onUpdateWebViewUrl()
                 }

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordViewModel.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordViewModel.kt
@@ -139,10 +139,14 @@ class AddWordViewModel @Inject constructor(
         }
     }
 
-    fun onShowWordSearchWebView() {
+    fun onShowWebView() {
         if (uiStateFlow.value.word.isNotEmpty()) {
             updateUiState(showWebView = true)
         }
+    }
+
+    fun onHideWebView() {
+        updateUiState(showWebView = false)
     }
 
     fun onUpdateWebViewUrl() {

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordViewModel.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordViewModel.kt
@@ -1,9 +1,11 @@
 package hsk.practice.myvoca.ui.screens.addword
 
+import android.util.Log
+import androidx.compose.runtime.State
+import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.accompanist.web.WebContent
-import com.google.accompanist.web.WebViewNavigator
 import com.google.accompanist.web.WebViewState
 import com.hsk.data.Vocabulary
 import com.hsk.data.VocabularyQuery
@@ -33,8 +35,10 @@ class AddWordViewModel @Inject constructor(
     val uiStateFlow: StateFlow<AddWordScreenData>
         get() = _uiStateFlow
 
-    val webViewState = WebViewState(WebContent.Url(url = _uiStateFlow.value.wordUrl))
-    val webViewNavigator = WebViewNavigator(viewModelScope)
+    private val _webViewState = mutableStateOf(WebViewState(WebContent.Url("")))
+
+    val webViewState: State<WebViewState>
+        get() = _webViewState
 
     /**
      * 단어 수정 화면이라면 [injectUpdateTarget] 함수를 이용하여 [updateTarget]를 초기화해야 한다.
@@ -139,8 +143,16 @@ class AddWordViewModel @Inject constructor(
         }
     }
 
-    fun updateWordUrl(wordUrl: String) {
-        updateUiState(wordUrl = wordUrl)
+    fun onShowWordSearchWebView() {
+        if (uiStateFlow.value.word.isNotEmpty()) {
+            updateUiState(showWebView = true)
+        }
+    }
+
+    fun onUpdateWordSearchWebViewUrl() {
+        Log.d("AddWordViewModel", uiStateFlow.value.word)
+        _webViewState.value =
+            WebViewState(WebContent.Url("https://dict.naver.com/dict.search?query=${uiStateFlow.value.word}"))
     }
 
     private fun updateUiState(
@@ -149,7 +161,8 @@ class AddWordViewModel @Inject constructor(
         wordExistStatus: WordExistStatus = uiStateFlow.value.wordExistStatus,
         meanings: ImmutableList<MeaningImpl> = uiStateFlow.value.meanings,
         memo: String = uiStateFlow.value.memo,
-        wordUrl: String = uiStateFlow.value.wordUrl
+        // wordUrl: String = uiStateFlow.value.wordUrl,
+        showWebView: Boolean = uiStateFlow.value.showWebView
     ) {
         _uiStateFlow.value = AddWordScreenData(
             screenType = screenType,
@@ -157,7 +170,7 @@ class AddWordViewModel @Inject constructor(
             wordExistStatus = wordExistStatus,
             meanings = meanings,
             memo = memo,
-            wordUrl = wordUrl,
+            showWebView = showWebView
         )
     }
 }
@@ -180,8 +193,7 @@ data class AddWordScreenData(
     val wordExistStatus: WordExistStatus = WordExistStatus.WORD_EMPTY,
     val meanings: ImmutableList<MeaningImpl> = persistentListOf(),
     val memo: String = "",
-    val wordUrl: String = "https://m.naver.com",
-    val showWebView: Boolean = true,
+    val showWebView: Boolean = false,
 ) {
     fun toVocabularyImpl(): VocabularyImpl {
         val current = System.currentTimeMillis()

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordViewModel.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordViewModel.kt
@@ -1,11 +1,9 @@
 package hsk.practice.myvoca.ui.screens.addword
 
-import android.util.Log
-import androidx.compose.runtime.State
-import androidx.compose.runtime.mutableStateOf
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.google.accompanist.web.WebContent
+import com.google.accompanist.web.WebViewNavigator
 import com.google.accompanist.web.WebViewState
 import com.hsk.data.Vocabulary
 import com.hsk.data.VocabularyQuery
@@ -35,10 +33,8 @@ class AddWordViewModel @Inject constructor(
     val uiStateFlow: StateFlow<AddWordScreenData>
         get() = _uiStateFlow
 
-    private val _webViewState = mutableStateOf(WebViewState(WebContent.Url("")))
-
-    val webViewState: State<WebViewState>
-        get() = _webViewState
+    val webViewState = WebViewState(WebContent.Url(url = ""))
+    val webViewNavigator = WebViewNavigator(viewModelScope)
 
     /**
      * 단어 수정 화면이라면 [injectUpdateTarget] 함수를 이용하여 [updateTarget]를 초기화해야 한다.
@@ -149,10 +145,8 @@ class AddWordViewModel @Inject constructor(
         }
     }
 
-    fun onUpdateWordSearchWebViewUrl() {
-        Log.d("AddWordViewModel", uiStateFlow.value.word)
-        _webViewState.value =
-            WebViewState(WebContent.Url("https://dict.naver.com/dict.search?query=${uiStateFlow.value.word}"))
+    fun onUpdateWebViewUrl() {
+        updateUiState(webViewUrl = "https://dict.naver.com/dict.search?query=${uiStateFlow.value.word}")
     }
 
     private fun updateUiState(
@@ -161,8 +155,8 @@ class AddWordViewModel @Inject constructor(
         wordExistStatus: WordExistStatus = uiStateFlow.value.wordExistStatus,
         meanings: ImmutableList<MeaningImpl> = uiStateFlow.value.meanings,
         memo: String = uiStateFlow.value.memo,
-        // wordUrl: String = uiStateFlow.value.wordUrl,
-        showWebView: Boolean = uiStateFlow.value.showWebView
+        showWebView: Boolean = uiStateFlow.value.showWebView,
+        webViewUrl: String = uiStateFlow.value.webViewUrl
     ) {
         _uiStateFlow.value = AddWordScreenData(
             screenType = screenType,
@@ -170,7 +164,8 @@ class AddWordViewModel @Inject constructor(
             wordExistStatus = wordExistStatus,
             meanings = meanings,
             memo = memo,
-            showWebView = showWebView
+            showWebView = showWebView,
+            webViewUrl = webViewUrl
         )
     }
 }
@@ -194,6 +189,7 @@ data class AddWordScreenData(
     val meanings: ImmutableList<MeaningImpl> = persistentListOf(),
     val memo: String = "",
     val showWebView: Boolean = false,
+    val webViewUrl: String = "",
 ) {
     fun toVocabularyImpl(): VocabularyImpl {
         val current = System.currentTimeMillis()

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordViewModel.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/addword/AddWordViewModel.kt
@@ -2,6 +2,9 @@ package hsk.practice.myvoca.ui.screens.addword
 
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.google.accompanist.web.WebContent
+import com.google.accompanist.web.WebViewNavigator
+import com.google.accompanist.web.WebViewState
 import com.hsk.data.Vocabulary
 import com.hsk.data.VocabularyQuery
 import com.hsk.domain.VocaPersistence
@@ -29,6 +32,9 @@ class AddWordViewModel @Inject constructor(
     private val _uiStateFlow = MutableStateFlow(AddWordScreenData())
     val uiStateFlow: StateFlow<AddWordScreenData>
         get() = _uiStateFlow
+
+    val webViewState = WebViewState(WebContent.Url(url = _uiStateFlow.value.wordUrl))
+    val webViewNavigator = WebViewNavigator(viewModelScope)
 
     /**
      * 단어 수정 화면이라면 [injectUpdateTarget] 함수를 이용하여 [updateTarget]를 초기화해야 한다.
@@ -133,22 +139,27 @@ class AddWordViewModel @Inject constructor(
         }
     }
 
+    fun updateWordUrl(wordUrl: String) {
+        updateUiState(wordUrl = wordUrl)
+    }
+
     private fun updateUiState(
         screenType: ScreenType = uiStateFlow.value.screenType,
         word: String = uiStateFlow.value.word,
         wordExistStatus: WordExistStatus = uiStateFlow.value.wordExistStatus,
         meanings: ImmutableList<MeaningImpl> = uiStateFlow.value.meanings,
-        memo: String = uiStateFlow.value.memo
+        memo: String = uiStateFlow.value.memo,
+        wordUrl: String = uiStateFlow.value.wordUrl
     ) {
         _uiStateFlow.value = AddWordScreenData(
             screenType = screenType,
             word = word,
             wordExistStatus = wordExistStatus,
             meanings = meanings,
-            memo = memo
+            memo = memo,
+            wordUrl = wordUrl,
         )
     }
-
 }
 
 sealed class ScreenType
@@ -169,6 +180,8 @@ data class AddWordScreenData(
     val wordExistStatus: WordExistStatus = WordExistStatus.WORD_EMPTY,
     val meanings: ImmutableList<MeaningImpl> = persistentListOf(),
     val memo: String = "",
+    val wordUrl: String = "https://m.naver.com",
+    val showWebView: Boolean = true,
 ) {
     fun toVocabularyImpl(): VocabularyImpl {
         val current = System.currentTimeMillis()

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/allword/AllWord.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/allword/AllWord.kt
@@ -37,7 +37,6 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
-import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.material3.contentColorFor
 import androidx.compose.runtime.*
@@ -61,6 +60,7 @@ import hsk.practice.myvoca.data.WordClassImpl
 import hsk.practice.myvoca.data.fakeData
 import hsk.practice.myvoca.data.toWordClass
 import hsk.practice.myvoca.ui.components.LoadingIndicator
+import hsk.practice.myvoca.ui.components.MyVocaText
 import hsk.practice.myvoca.ui.components.WordContent
 import hsk.practice.myvoca.ui.state.UiState
 import hsk.practice.myvoca.ui.theme.MyVocaTheme
@@ -242,7 +242,7 @@ private fun SearchOptionClearButton(
                 imageVector = Icons.Filled.Refresh,
                 contentDescription = "검색 옵션을 초기화합니다."
             )
-            Text(text = "초기화")
+            MyVocaText(text = "초기화")
         }
     }
 }
@@ -254,7 +254,7 @@ private fun ShowSearchOptionButton(onButtonClicked: () -> Unit) {
             imageVector = Icons.Filled.ManageSearch,
             contentDescription = "특정 조건에 맞는 단어를 검색합니다."
         )
-        Text(text = "검색 옵션")
+        MyVocaText(text = "검색 옵션")
     }
 }
 
@@ -263,7 +263,7 @@ private fun HeaderText(
     vocabularySize: Int,
     modifier: Modifier = Modifier
 ) {
-    Text(
+    MyVocaText(
         text = "검색 결과: ${vocabularySize}개",
         modifier = modifier
     )
@@ -350,7 +350,7 @@ private fun CloseQueryButton(
         },
         modifier = modifier
     ) {
-        Text("닫기")
+        MyVocaText(text = "닫기")
     }
 }
 
@@ -367,7 +367,7 @@ private fun SubmitQueryButton(
         },
         modifier = modifier
     ) {
-        Text("검색")
+        MyVocaText(text = "검색")
     }
 }
 
@@ -380,7 +380,7 @@ private fun QueryWord(
     OutlinedTextField(
         modifier = Modifier.fillMaxWidth(),
         value = text,
-        label = { Text(text = "단어") },
+        label = { MyVocaText(text = "단어") },
         trailingIcon = {
             if (text.isNotEmpty()) {
                 IconButton(onClick = { onTextChanged("") }) {
@@ -447,7 +447,7 @@ private fun WordClassChip(
                 tint = textColor
             )
         }
-        Text(
+        MyVocaText(
             text = className,
             modifier = Modifier.padding(6.dp),
             color = textColor
@@ -498,7 +498,7 @@ private fun SortStateChip(
             .clickable { onClick(sortState) },
         contentAlignment = Alignment.Center,
     ) {
-        Text(
+        MyVocaText(
             text = sortState.korean,
             color = textColor,
             textAlign = TextAlign.Center,

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/allword/AllWord.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/allword/AllWord.kt
@@ -52,6 +52,7 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.min
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.hsk.data.VocabularyQuery
 import com.hsk.data.WordClass
@@ -75,7 +76,7 @@ import kotlinx.coroutines.launch
 fun AllWordScreen(
     viewModel: AllWordViewModel = viewModel()
 ) {
-    val uiState by viewModel.allWordUiState.collectAsState()
+    val uiState by viewModel.allWordUiState.collectAsStateWithLifecycle()
 
     Loading(
         uiState = uiState,

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/home/HomeScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -34,6 +33,7 @@ import androidx.compose.ui.draw.alpha
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.work.WorkManager
 import hsk.practice.myvoca.data.TodayWordImpl
 import hsk.practice.myvoca.data.fakeData
@@ -50,7 +50,7 @@ import java.time.ZoneOffset
 
 @Composable
 fun HomeScreen(viewModel: HomeViewModel) {
-    val homeScreenData by viewModel.homeScreenData.collectAsState()
+    val homeScreenData by viewModel.homeScreenData.collectAsStateWithLifecycle()
 
     val context = LocalContext.current
     LaunchedEffect(true) {

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/home/HomeScreen.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/home/HomeScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.Checkbox
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -39,9 +38,9 @@ import androidx.work.WorkManager
 import hsk.practice.myvoca.data.TodayWordImpl
 import hsk.practice.myvoca.data.fakeData
 import hsk.practice.myvoca.ui.components.LoadingIndicator
+import hsk.practice.myvoca.ui.components.MyVocaText
 import hsk.practice.myvoca.ui.components.WordContent
 import hsk.practice.myvoca.ui.theme.MyVocaTheme
-import hsk.practice.myvoca.ui.theme.Paybooc
 import hsk.practice.myvoca.util.getTimeDiffString
 import hsk.practice.myvoca.work.setPeriodicTodayWordWork
 import kotlinx.collections.immutable.ImmutableList
@@ -168,7 +167,7 @@ private fun TodayWordItems(
 @Composable
 private fun TodayWordEmptyIndicator() {
     Box(modifier = Modifier.fillMaxSize()) {
-        Text(
+        MyVocaText(
             text = "아직 아무것도 없습니다.",
             modifier = Modifier.align(Alignment.Center)
         )
@@ -213,7 +212,7 @@ private fun RefreshIcon(onRefreshTodayWord: () -> Unit, enableRefresh: Boolean) 
 
 @Composable
 private fun LastUpdateTimeText(lastUpdatedTimeString: String) {
-    Text(
+    MyVocaText(
         text = "마지막 업데이트: $lastUpdatedTimeString",
         style = MaterialTheme.typography.bodySmall
     )
@@ -233,7 +232,7 @@ private fun HelpIcon(showTodayWordHelp: (Boolean) -> Unit) {
 
 @Composable
 private fun HeaderTitle() {
-    Text(
+    MyVocaText(
         text = "오늘의 단어",
         style = MaterialTheme.typography.titleLarge
     )
@@ -271,7 +270,7 @@ private fun TodayWordContent(
 @Composable
 private fun Title(size: Int = 0) {
     val titleText = if (size == 0) "등록된 단어가\n없습니다" else "${size}개의 단어가\n등록되어 있어요"
-    Text(
+    MyVocaText(
         text = titleText,
         maxLines = 2,
         style = MaterialTheme.typography.headlineMedium,
@@ -285,21 +284,12 @@ private fun TodayWordHelp(
 ) {
     AlertDialog(
         title = {
-            Text(
-                text = "오늘의 단어란?",
-                fontFamily = Paybooc
-            )
+            MyVocaText(text = "오늘의 단어란?",)
         },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                Text(
-                    text = "매일매일 새로운 단어를 외워 보세요. 단어는 하루마다 갱신됩니다.",
-                    fontFamily = Paybooc
-                )
-                Text(
-                    text = "외운 단어는 체크 표시로 구분할 수 있습니다.",
-                    fontFamily = Paybooc
-                )
+                MyVocaText(text = "매일매일 새로운 단어를 외워 보세요. 단어는 하루마다 갱신됩니다.",)
+                MyVocaText(text = "외운 단어는 체크 표시로 구분할 수 있습니다.")
             }
         },
         confirmButton = {
@@ -310,10 +300,7 @@ private fun TodayWordHelp(
                 contentAlignment = Alignment.CenterEnd
             ) {
                 TextButton(onClick = onClose) {
-                    Text(
-                        text = "확인",
-                        fontFamily = Paybooc
-                    )
+                    MyVocaText(text = "확인")
                 }
             }
         },

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/profile/ProfileScreen.kt
@@ -11,7 +11,17 @@ import androidx.compose.animation.animateColorAsState
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material.icons.Icons
@@ -20,7 +30,6 @@ import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
@@ -39,6 +48,7 @@ import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import coil.transform.CircleCropTransformation
 import hsk.practice.myvoca.firebase.UserImpl
+import hsk.practice.myvoca.ui.components.MyVocaText
 import hsk.practice.myvoca.ui.theme.MyVocaTheme
 
 @Composable
@@ -152,13 +162,13 @@ private fun UserInfo(
 @Composable
 private fun LogOutButton(onLogout: () -> Unit) {
     TextButton(onClick = onLogout) {
-        Text(text = "로그아웃")
+        MyVocaText(text = "로그아웃")
     }
 }
 
 @Composable
 private fun UserEmail(email: String) {
-    Text(
+    MyVocaText(
         text = email,
         style = MaterialTheme.typography.displayLarge
     )
@@ -166,7 +176,7 @@ private fun UserEmail(email: String) {
 
 @Composable
 private fun Username(username: String) {
-    Text(
+    MyVocaText(
         text = username,
         style = MaterialTheme.typography.headlineSmall
     )
@@ -184,7 +194,7 @@ private fun Login(
 
     val context = LocalContext.current
     TextButton(onClick = { onLoginButtonClick(context, googleLoginLauncher) }) {
-        Text(text = "로그인하기")
+        MyVocaText(text = "로그인하기")
     }
 }
 
@@ -251,7 +261,7 @@ private fun UserActionUploadWords(
                 )
             }
         }
-        Text(text = actionData.text)
+        MyVocaText(text = actionData.text)
     }
 
     if (data.showUploadDialog) {
@@ -278,7 +288,7 @@ private fun UserActionDownloadWords(data: DownloadActionData) {
             contentDescription = actionData.text,
             modifier = Modifier.fillMaxSize(fraction = actionIconFraction)
         )
-        Text(text = actionData.text)
+        MyVocaText(text = actionData.text)
     }
 
     if (data.showDownloadDialog) {
@@ -292,21 +302,21 @@ private fun UploadDialog(
     onDismiss: () -> Unit
 ) {
     AlertDialog(
-        title = { Text(text = "단어 백업하기") },
+        title = { MyVocaText(text = "단어 백업하기") },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                Text(text = "단어를 백업하시겠습니까?")
-                Text(text = "단어는 클라우드에 백업되며, 언제든지 앱으로 가져올 수 있습니다.")
+                MyVocaText(text = "단어를 백업하시겠습니까?")
+                MyVocaText(text = "단어는 클라우드에 백업되며, 언제든지 앱으로 가져올 수 있습니다.")
             }
         },
         confirmButton = {
             TextButton(onClick = onConfirm) {
-                Text(text = "확인")
+                MyVocaText(text = "확인")
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text(text = "취소")
+                MyVocaText(text = "취소")
             }
         },
         onDismissRequest = onDismiss
@@ -319,21 +329,21 @@ private fun DownloadDialog(
     onDismiss: () -> Unit
 ) {
     AlertDialog(
-        title = { Text(text = "단어 복원하기") },
+        title = { MyVocaText(text = "단어 복원하기") },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(4.dp)) {
-                Text(text = "단어를 복원하시겠습니까?")
-                Text(text = "클라우드의 데이터를 기기로 복원합니다.")
+                MyVocaText(text = "단어를 복원하시겠습니까?")
+                MyVocaText(text = "클라우드의 데이터를 기기로 복원합니다.")
             }
         },
         confirmButton = {
             TextButton(onClick = onConfirm) {
-                Text(text = "확인")
+                MyVocaText(text = "확인")
             }
         },
         dismissButton = {
             TextButton(onClick = onDismiss) {
-                Text(text = "취소")
+                MyVocaText(text = "취소")
             }
         },
         onDismissRequest = onDismiss

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/profile/ProfileScreen.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/profile/ProfileScreen.kt
@@ -32,7 +32,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -44,6 +43,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil.compose.rememberAsyncImagePainter
 import coil.request.ImageRequest
 import coil.transform.CircleCropTransformation
@@ -53,7 +53,7 @@ import hsk.practice.myvoca.ui.theme.MyVocaTheme
 
 @Composable
 fun ProfileScreen(viewModel: ProfileViewModel = hiltViewModel()) {
-    val data by viewModel.profileScreenData.collectAsState()
+    val data by viewModel.profileScreenData.collectAsStateWithLifecycle()
 
     Content(
         data = data,

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/quiz/QuizScreen.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/quiz/QuizScreen.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.*
 import androidx.compose.ui.Alignment
@@ -27,13 +26,13 @@ import com.hsk.ktx.truncate
 import hsk.practice.myvoca.data.VocabularyImpl
 import hsk.practice.myvoca.data.fakeData
 import hsk.practice.myvoca.ui.components.LoadingIndicator
+import hsk.practice.myvoca.ui.components.MyVocaText
 import hsk.practice.myvoca.ui.components.WordContent
 import hsk.practice.myvoca.ui.components.WordMeanings
 import hsk.practice.myvoca.ui.components.versus.VersusView
 import hsk.practice.myvoca.ui.components.versus.rememberVersusViewState
 import hsk.practice.myvoca.ui.screens.addword.AddWordActivity
 import hsk.practice.myvoca.ui.theme.MyVocaTheme
-import hsk.practice.myvoca.ui.theme.Paybooc
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
 
@@ -91,9 +90,8 @@ private fun QuizNotAvailable(need: Int) {
         horizontalAlignment = Alignment.CenterHorizontally,
         verticalArrangement = Arrangement.Center
     ) {
-        Text(
+        MyVocaText(
             text = "${need}개의 단어가 더 필요합니다.",
-            fontFamily = Paybooc,
             style = MaterialTheme.typography.headlineSmall,
             textAlign = TextAlign.Center
         )
@@ -106,10 +104,7 @@ private fun QuizNotAvailable(need: Int) {
                 imageVector = Icons.Outlined.Add,
                 contentDescription = "클릭하여 단어를 추가합니다."
             )
-            Text(
-                text = "단어 추가하러 가기",
-                fontFamily = Paybooc,
-            )
+            MyVocaText(text = "단어 추가하러 가기")
         }
     }
 }
@@ -151,7 +146,7 @@ private fun QuizTitle(answer: VocabularyImpl) {
     val textStyleTitle3 = MaterialTheme.typography.displaySmall
     val (textStyle, updateTextStyle) = remember { mutableStateOf(textStyleTitle3) }
     Box(modifier = Modifier.fillMaxWidth()) {
-        Text(
+        MyVocaText(
             text = answer.eng,
             style = textStyle,
             maxLines = 1,
@@ -211,7 +206,7 @@ private fun Result(
     val title = if (resultData.result is QuizCorrect) "맞았습니다!!" else "틀렸습니다"
     AlertDialog(
         title = {
-            Text(text = title)
+            MyVocaText(text = title)
         },
         text = {
             WordContent(resultData.answer)
@@ -224,7 +219,7 @@ private fun Result(
                 contentAlignment = Alignment.CenterEnd
             ) {
                 TextButton(onClick = { onCloseDialog(resultData) }) {
-                    Text("확인")
+                    MyVocaText(text = "확인")
                 }
             }
         },
@@ -253,7 +248,7 @@ private fun QuizScreenPreview() {
 
     MyVocaTheme {
         Column {
-            Text(text = text)
+            MyVocaText(text = text)
             QuizContent(
                 quiz = quiz,
                 quizStat = quizStat,

--- a/app/src/main/java/hsk/practice/myvoca/ui/screens/quiz/QuizScreen.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/screens/quiz/QuizScreen.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.hsk.ktx.distinctRandoms
 import com.hsk.ktx.truncate
 import hsk.practice.myvoca.data.VocabularyImpl
@@ -38,7 +39,7 @@ import kotlinx.collections.immutable.toImmutableList
 
 @Composable
 fun QuizScreen(viewModel: QuizViewModel) {
-    val quizScreenData by viewModel.quizScreenData.collectAsState()
+    val quizScreenData by viewModel.quizScreenData.collectAsStateWithLifecycle()
 
     Loading(
         quizScreenData = quizScreenData,

--- a/app/src/main/java/hsk/practice/myvoca/ui/structure/Splash.kt
+++ b/app/src/main/java/hsk/practice/myvoca/ui/structure/Splash.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.ui.Alignment
@@ -18,6 +17,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import hsk.practice.myvoca.ui.components.MyVocaText
 import hsk.practice.myvoca.ui.theme.MyVocaTheme
 import kotlinx.coroutines.delay
 
@@ -105,12 +105,12 @@ private fun Logo() {
         verticalArrangement = Arrangement.Center,
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        Text(
+        MyVocaText(
             text = "나만의 단어장",
             style = MaterialTheme.typography.headlineMedium,
             color = MaterialTheme.colorScheme.onBackground
         )
-        Text(
+        MyVocaText(
             text = "MyVoca",
             style = MaterialTheme.typography.headlineMedium,
             color = MaterialTheme.colorScheme.onBackground

--- a/build.gradle
+++ b/build.gradle
@@ -30,7 +30,7 @@ buildscript {
         classpath "com.google.dagger:hilt-android-gradle-plugin:$hilt_version"
         // Firebase integration
         classpath 'com.google.gms:google-services:4.4.0'
-        classpath 'org.jacoco:org.jacoco.core:0.8.7'
+        classpath "org.jacoco:org.jacoco.core:$jacoco_version"
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
- 단어 검색을 위한 웹뷰가 화면의 하단 반을 차지하도록 UI 구성 

- 기존 화면이 스크롤 되도록 스크롤 기능 추가

- 단어를 입력하고 검색 버튼을 누르면 웹뷰가 띄워지고, 단어를 변경하고 검색버튼을 누르면 웹뷰가 갱신되도록 구현 

- TopBar 의 완료 버튼을 눌러 웹뷰를 닫을 수 있도록 구현 